### PR TITLE
site: sticky footer + drop last-blog divider

### DIFF
--- a/site/styles.css
+++ b/site/styles.css
@@ -140,6 +140,7 @@
   .post-list{padding:24px 0 60px;display:flex;flex-direction:column}
   .post{padding:34px 0;border-bottom:1px solid var(--border);cursor:pointer;text-align:left;background:none;border-left:0;border-right:0;border-top:0;width:100%;font-family:inherit;color:inherit}
   .post:first-child{border-top:0}
+  .post:last-child{border-bottom:0}
   .post h3{font-size:22px;font-weight:700;margin:0 0 6px;transition:color .2s}
   .post:hover h3{color:var(--accent-ink)}
   .post .date{font-size:14px;color:var(--muted-2);margin:0 0 12px}

--- a/site/styles.css
+++ b/site/styles.css
@@ -226,3 +226,7 @@
   /* markdown tables: right-align numeric columns */
   .art-body th:not(:first-child),.art-body td:not(:first-child){text-align:right}
   .art-body td{font-variant-numeric:tabular-nums}
+
+  /* sticky footer: on short pages, pin the footer to the bottom of the viewport */
+  body{min-height:100vh;display:flex;flex-direction:column}
+  main{flex:1 0 auto}


### PR DESCRIPTION
Two small fixes to the site (the initial site landed in #1; these were made after that merge):

- **Sticky footer** — on short pages (the blog index) the footer floated mid-viewport with blank space beneath it. `body` is now a flex column and `main` grows, pinning the footer to the bottom.
- **Drop the divider below the last blog post** — `.post:last-child` no longer draws a bottom hairline.

Merge to get these onto `main` for your Vercel deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)