### PR TITLE
Prepare for official MCP registry listing (marker + server.json + site URL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- mcp-name: io.github.prithviseran/hunch -->
 <p align="center">
   <img src="https://raw.githubusercontent.com/PrithviSeran/hunch-mcp/main/src/hunch/assets/hunch.png" alt="Hunch" width="128">
 </p>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,5 +42,6 @@ packages = ["src/hunch"]
 hunch = "hunch.cli:main"
 
 [project.urls]
-Homepage = "https://github.com/prithviseran/hunch-mcp"
-Issues = "https://github.com/prithviseran/hunch-mcp/issues"
+Homepage = "https://www.tryhunch.ca"
+Repository = "https://github.com/PrithviSeran/hunch-mcp"
+Issues = "https://github.com/PrithviSeran/hunch-mcp/issues"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,17 @@
+{
+  "name": "io.github.prithviseran/hunch",
+  "description": "Focus-free macOS control for AI agents: drive your real Mac apps in the background, no stolen focus.",
+  "version": "0.5.2",
+  "repository": {
+    "url": "https://github.com/PrithviSeran/hunch-mcp",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "hunch-sdk",
+      "version": "0.5.2",
+      "transport": { "type": "stdio" }
+    }
+  ]
+}


### PR DESCRIPTION
Code-side prep so `hunch-sdk` can be published to the official MCP registry. After merge, the publish steps are yours (they need your PyPI + GitHub auth).

## Changes
- **README** — adds the ownership marker `mcp-name: io.github.prithviseran/hunch` as an invisible HTML comment. The registry verifies ownership by finding this string in the **PyPI description**, which is `README.md`.
- **pyproject** — `Homepage` now points to https://www.tryhunch.ca; added an explicit `Repository` URL.
- **server.json** — the registry manifest (pypi package `hunch-sdk`, stdio transport, namespace `io.github.prithviseran/hunch`).

## Publish flow (after merge)
1. **Release to PyPI so the marker is live** — your live version is `0.5.0`; this ships `0.5.2`:
   ```
   python -m build && twine upload dist/*
   ```
   (If `0.5.2` is taken, bump to `0.5.3` in `pyproject.toml` **and** `server.json`.)
2. **Publish to the registry:**
   ```
   mcp-publisher init          # optional: regenerates server.json against the current schema
   mcp-publisher login github  # must be the PrithviSeran account
   mcp-publisher publish --dry-run
   mcp-publisher publish
   ```
   `--dry-run` validates `server.json`; if the schema changed, run `init` and copy these values across.

This one publish cascades to PulseMCP, VS Code `@mcp`, Cursor, and other registry consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)