### PR TITLE
Sync main with published 0.5.3 (sdist fix, registry casing/schema, mcp.json)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- mcp-name: io.github.prithviseran/hunch -->
+<!-- mcp-name: io.github.PrithviSeran/hunch -->
 <p align="center">
   <img src="https://raw.githubusercontent.com/PrithviSeran/hunch-mcp/main/src/hunch/assets/hunch.png" alt="Hunch" width="128">
 </p>

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "hunch": {
+      "command": "hunch",
+      "args": ["serve"]
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hunch-sdk"
-version = "0.5.2"
+version = "0.5.3"
 description = "Drive your Mac focus-free over MCP: OS APIs, AppleScript, CDP, and Accessibility."
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,10 @@ agent = ["anthropic>=0.80", "claude-agent-sdk>=0.2"]   # both backends
 [tool.hatch.build.targets.wheel]
 packages = ["src/hunch"]
 
+[tool.hatch.build.targets.sdist]
+# ship only the package + metadata; keep bench/, site/, etc. out of the sdist
+include = ["src/hunch", "README.md", "LICENSE"]
+
 [project.scripts]
 hunch = "hunch.cli:main"
 

--- a/server.json
+++ b/server.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.prithviseran/hunch",
   "description": "Focus-free macOS control for AI agents: drive your real Mac apps in the background, no stolen focus.",
   "version": "0.5.2",
@@ -11,7 +12,9 @@
       "registryType": "pypi",
       "identifier": "hunch-sdk",
       "version": "0.5.2",
-      "transport": { "type": "stdio" }
+      "transport": {
+        "type": "stdio"
+      }
     }
   ]
 }

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.PrithviSeran/hunch",
   "description": "Focus-free macOS control for AI agents: drive your real Mac apps in the background, no stolen focus.",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "repository": {
     "url": "https://github.com/PrithviSeran/hunch-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "pypi",
       "identifier": "hunch-sdk",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "transport": {
         "type": "stdio"
       }

--- a/server.json
+++ b/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.prithviseran/hunch",
+  "name": "io.github.PrithviSeran/hunch",
   "description": "Focus-free macOS control for AI agents: drive your real Mac apps in the background, no stolen focus.",
   "version": "0.5.2",
   "repository": {


### PR DESCRIPTION
PR #3 merged only its first commit; these 5 follow-ups landed on the branch afterward and never reached `main`, so `main` is currently stale relative to what's published.

Brings onto `main`:
- **`67f0ac9`** — restrict the sdist to the package (**368 MB → 184 KB**; `bench/` was being swept in). Without this, building from `main` reproduces the 368 MB sdist.
- **`f28bcef`** — add the required `$schema` to `server.json`.
- **`1cc6d21`** — match the GitHub namespace casing (`io.github.PrithviSeran/...`) in `server.json` + the README `mcp-name` marker.
- **`6e58dda`** — bump to **0.5.3** (the version actually on PyPI + in the registry).
- **`4b854a4`** — add `mcp.json` (Cursor Directory / Open Plugins auto-detect).

After this, `main` matches the published `hunch-sdk 0.5.3` and the registry entry `io.github.PrithviSeran/hunch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)