### PR TITLE
feat(agent): injectable can_use_tool hook + Agent.interrupt() (0.5.4)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hunch-sdk"
-version = "0.5.3"
+version = "0.5.4"
 description = "Drive your Mac focus-free over MCP: OS APIs, AppleScript, CDP, and Accessibility."
 readme = "README.md"
 license = "Apache-2.0"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.PrithviSeran/hunch",
   "description": "Focus-free macOS control for AI agents: drive your real Mac apps in the background, no stolen focus.",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "repository": {
     "url": "https://github.com/PrithviSeran/hunch-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "pypi",
       "identifier": "hunch-sdk",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "transport": {
         "type": "stdio"
       }

--- a/src/hunch/__init__.py
+++ b/src/hunch/__init__.py
@@ -5,7 +5,7 @@ doctor) must work even when pyobjc or the MCP SDK are missing, so nothing here
 may import them. The server loads lazily via `hunch serve`.
 """
 
-__version__ = "0.5.0"
+__version__ = "0.5.4"
 
 # Public SDK surface, loaded lazily (PEP 562) so bare `import hunch` stays dependency-free.
 # Names mapped to .sdk/.agent/.local_mac pull in pyobjc; .errors and .auth stay stdlib-only,

--- a/src/hunch/agent.py
+++ b/src/hunch/agent.py
@@ -415,10 +415,11 @@ class _SubscriptionRunner:
     run_coroutine_threadsafe, so Agent.run() stays synchronous. The connected client
     is kept across run() calls (continuation) while the options are unchanged."""
 
-    def __init__(self, hunch, auth=None, app_id=None):
+    def __init__(self, hunch, auth=None, app_id=None, can_use_tool=None):
         self._h = hunch
         self._auth = auth              # OAuthToken (injected) or None (ambient)
         self._app_id = app_id
+        self._permit = can_use_tool    # host-owned permission callback (see Agent.__init__)
         self._loop = None
         self._thread = None
         self._client = None
@@ -460,11 +461,9 @@ class _SubscriptionRunner:
         system = HUNCH_PLAYBOOK + "\n" + AGENT_ADDENDUM
         if system_suffix:
             system += "\n" + system_suffix
-        return sdk.ClaudeAgentOptions(
+        opts = dict(
             system_prompt=system,
             mcp_servers={"hunch": sdk.create_sdk_mcp_server("hunch", tools=_sdk_tools(self._h))},
-            allowed_tools=[f"mcp__hunch__{t['name']}" for t in AGENT_TOOLS],
-            can_use_tool=_allow_hunch_only,
             permission_mode="default",         # unmatched tools -> can_use_tool (our policy point)
             setting_sources=[],                # ignore the user's .claude / .mcp.json entirely
             model=model,                       # None -> the subscription's default model
@@ -473,6 +472,16 @@ class _SubscriptionRunner:
             env=env,                           # {} or the injected/namespaced OAuth token
             max_buffer_size=16 * 1024 * 1024,  # snapshots/screenshots exceed the 1MB default
         )
+        if self._permit is not None:
+            # A host (e.g. the Hunch app) owns approval: its callback governs EVERY tool, so we
+            # don't restrict allowed_tools — built-in Read/Grep/etc. reach it too, exactly like a
+            # raw claude-agent-sdk can_use_tool. The callback must match that (tool_name, input,
+            # context) -> PermissionResultAllow/Deny protocol.
+            opts["can_use_tool"] = self._permit
+        else:
+            opts["can_use_tool"] = _allow_hunch_only
+            opts["allowed_tools"] = [f"mcp__hunch__{t['name']}" for t in AGENT_TOOLS]
+        return sdk.ClaudeAgentOptions(**opts)
 
     # — the loop —
     async def _run_async(self, client, task, emit):
@@ -523,6 +532,18 @@ class _SubscriptionRunner:
         emit = on_event or (lambda kind, data: None)
         return self._call(self._run_async(self._client, task, emit))
 
+    def interrupt(self):
+        """Interrupt the in-flight turn (the SDK's own interrupt) WITHOUT tearing down the
+        conversation — the next run() continues the same context. Called from another thread
+        (e.g. a Stop button) while run() blocks on the loop; a no-op if nothing is connected."""
+        if self._client is None or self._loop is None:
+            return
+        import asyncio
+        try:
+            asyncio.run_coroutine_threadsafe(self._client.interrupt(), self._loop).result(timeout=5)
+        except Exception:
+            pass
+
     def reset(self):
         if self._client is not None:
             client, self._client, self._opts_key = self._client, None, None
@@ -553,13 +574,19 @@ class Agent:
     """The agent loop. Created lazily as `Hunch.agent`. Holds conversation state across
     run() calls (continuation); call reset() to start a fresh task."""
 
-    def __init__(self, hunch, client=None, backend="auto", auth=None):
+    def __init__(self, hunch, client=None, backend="auto", auth=None, can_use_tool=None):
         from .auth import ApiKey, OAuthToken
         self._h = hunch
         self._client = client          # test seam; None -> lazily anthropic.Anthropic()
         self.backend = backend         # "auto" | "api" | "subscription" (per-run override too)
         self.auth = auth               # None (ambient) | ApiKey | OAuthToken | "none"
+        # Optional host-owned permission callback. When set, the subscription backend hands EVERY
+        # tool to it — a raw claude-agent-sdk can_use_tool(tool_name, input, context) ->
+        # PermissionResultAllow/Deny — instead of auto-allowing Hunch tools. This is how the Hunch
+        # app routes each tool through its own Approve/Deny UI. (Subscription backend only.)
+        self._can_use_tool = can_use_tool
         self.messages = []
+        self._abort = False            # api backend: between-turns cancel flag (see interrupt())
         self._sub = None               # _SubscriptionRunner, built on first subscription run
         if not (auth is None or auth == "none" or isinstance(auth, (ApiKey, OAuthToken))):
             raise HunchError(f"unknown auth {auth!r} — pass hunch.ApiKey(...), "
@@ -628,6 +655,14 @@ class Agent:
             self._sub.close()
             self._sub = None
 
+    def interrupt(self):
+        """Stop an in-flight run() while KEEPING the conversation (the next run() continues it).
+        Call from another thread (e.g. a Stop button). Subscription backend: interrupts the current
+        turn immediately; api backend: cancels before the next turn. No-op if nothing is running."""
+        self._abort = True                        # api backend: checked between turns
+        if self._sub is not None:
+            self._sub.interrupt()                 # subscription backend: immediate
+
     def _ensure_client(self):
         if self._client is None:
             from .auth import ApiKey
@@ -680,7 +715,7 @@ class Agent:
                 from .auth import OAuthToken
                 self._sub = _SubscriptionRunner(
                     self._h, auth=self.auth if isinstance(self.auth, OAuthToken) else None,
-                    app_id=self._app_id)
+                    app_id=self._app_id, can_use_tool=self._can_use_tool)
             return self._sub.run(task, model=model, max_turns=max_turns, on_event=on_event,
                                  system_suffix=system_suffix, effort=effort)
 
@@ -695,8 +730,13 @@ class Agent:
         self.messages.append({"role": "user", "content": task})
         usage = {}
         stop_reason, final_text, aborted, turn = "max_turns", "", True, 0
+        self._abort = False
 
         for turn in range(1, max_turns + 1):
+            if self._abort:                       # interrupt() between turns (api backend)
+                stop_reason, aborted = "interrupted", True
+                emit("error", "interrupted")
+                break
             _mark_cache(self.messages)
             try:
                 resp = self._request(client, model, max_tokens, self._system(system_suffix), effort)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -394,6 +394,62 @@ def test_subscription_run_error_result():
     assert events == [("error", "stopped: error_max_turns")]
 
 
+class _FakeSdk:
+    """Enough of claude_agent_sdk for _options() to build an inspectable options dict."""
+    def create_sdk_mcp_server(self, name, tools):
+        return ("srv", name, tools)
+
+    class ClaudeAgentOptions:
+        def __init__(self, **kw):
+            self.kw = kw
+
+    class PermissionResultAllow:
+        pass
+
+    class PermissionResultDeny:
+        def __init__(self, message=""):
+            self.message = message
+
+
+def test_subscription_custom_permit_governs_all_tools():
+    """A host-injected can_use_tool becomes the options callback AND relaxes allowed_tools,
+    so built-in (non-Hunch) tools reach the host's approver too."""
+    async def permit(tool_name, input_data, context):
+        return "ALLOWED"
+    r = agent_mod._SubscriptionRunner(_FakeHunch(), can_use_tool=permit)
+    opts = r._options(_FakeSdk(), None, 40, "", None, {}).kw
+    assert opts["can_use_tool"] is permit
+    assert "allowed_tools" not in opts        # host owns permission for EVERY tool
+
+
+def test_subscription_default_permit_is_hunch_only():
+    import asyncio
+    r = agent_mod._SubscriptionRunner(_FakeHunch())      # no custom callback
+    opts = r._options(_FakeSdk(), None, 40, "", None, {}).kw
+    assert opts["allowed_tools"] == [f"mcp__hunch__{t['name']}" for t in AGENT_TOOLS]
+    deny = asyncio.run(opts["can_use_tool"]("Bash", {}, None))
+    assert type(deny).__name__ == "PermissionResultDeny"          # non-Hunch tool denied
+    allow = asyncio.run(opts["can_use_tool"]("mcp__hunch__snapshot", {}, None))
+    assert type(allow).__name__ == "PermissionResultAllow"
+
+
+def test_agent_forwards_can_use_tool_to_subscription():
+    async def permit(tool_name, input_data, context):
+        return "ALLOWED"
+    a = Agent(_FakeHunch(), can_use_tool=permit)
+    assert a._can_use_tool is permit
+
+
+def test_agent_interrupt_sets_abort_and_delegates():
+    a = Agent(_FakeHunch())
+    a.interrupt()                     # no subscription runner yet -> just arms the api abort flag
+    assert a._abort is True
+    calls = []
+    a._sub = types.SimpleNamespace(interrupt=lambda: calls.append("i"))
+    a.interrupt()
+    assert calls == ["i"]             # delegates to the subscription runner when present
+
+
 # ── auth resolution (the hunch.login() surface) ─────────────────────────────────
 
 def test_auth_resolution_order(monkeypatch):


### PR DESCRIPTION
## What

Two additive capabilities on `hunch.Agent` so an external host can drive the agent loop with **its own permission UX and a stop button**. This lets the Hunch macOS app consume the SDK's agent loop directly instead of vendoring the engine and spawning an out-of-process `hunch serve` MCP server.

- **`Agent(..., can_use_tool=cb)`** — host-owned approval. When set, the subscription backend routes **every** tool through the host callback (a raw claude-agent-sdk `can_use_tool(tool_name, input, context) -> PermissionResultAllow/Deny`) instead of auto-allowing Hunch tools, and relaxes `allowed_tools` so built-in tools reach it too.
- **`Agent.interrupt()`** — stop an in-flight `run()` while **keeping** the conversation (the next `run()` continues it). Subscription backend interrupts the current turn immediately; the api backend cancels before the next turn.

## Compatibility

Fully backward compatible — default behavior is unchanged when neither param is used. All existing tests pass; **4 new tests** cover the hook + interrupt.

## Version

`0.5.3 → 0.5.4` in `pyproject.toml`, `server.json`, and `src/hunch/__init__.py` (the last was stale at `0.5.0`).

## Test

```
100 passed
```

## Release note

On publish of 0.5.4, per repo convention also bump the separate `homebrew-hunch` formula. The Hunch app pins `hunch-sdk[subscription]>=0.5.4` and depends on this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)