### PR TITLE
Focus-free typing into Cursor/VS Code terminals via CDP

### DIFF
--- a/src/hunch/agent.py
+++ b/src/hunch/agent.py
@@ -122,7 +122,11 @@ AGENT_TOOLS = [
      "description": ("Open a Chromium browser or Electron app for FOCUS-FREE control over CDP — "
                      "the way to drive web/Electron apps in the background. `app` is the browser "
                      "(default 'Google Chrome'); put a website in `url`. Uses the persistent Hunch "
-                     "profile; call web_login once if it isn't signed in."),
+                     "profile; call web_login once if it isn't signed in. CODE EDITORS: app="
+                     "'Cursor'/'Visual Studio Code'/'VSCodium'/'Windsurf' with the FOLDER/FILE in "
+                     "`url` opens a dedicated background editor window whose integrated TERMINAL you "
+                     "can type into (AX can't write it) — snapshot, then web_act 'type' on the "
+                     "'Terminal' tab (trailing newline runs the command); key ctrl+` opens one."),
      "input_schema": _obj({"app": {"type": "string"}, "url": {"type": "string"},
                            "isolated": {"type": "boolean"}})},
     {"name": "web_login",

--- a/src/hunch/cdp.py
+++ b/src/hunch/cdp.py
@@ -12,7 +12,9 @@ the same agent loop.
 """
 
 import os
+import re
 import json
+import zlib
 import time
 import socket
 import subprocess
@@ -68,6 +70,57 @@ def _resolve_app(app_name):
     return _BROWSER_ALIASES.get((app_name or "").strip().lower(), app_name)
 
 
+# ── Electron code editors — drivable over CDP exactly like a browser ──────────────────────
+# Their integrated terminal is xterm.js, which AX can READ but never WRITE (the AX value-set
+# lands in a screen-reader mirror, not the PTY). Over CDP we inject REAL keystrokes into the
+# renderer, so the terminal — and its running claude/shell — becomes focus-free-typeable.
+_EDITOR_ALIASES = {
+    "cursor": "Cursor",
+    "code": "Visual Studio Code", "vscode": "Visual Studio Code",
+    "vs code": "Visual Studio Code", "visual studio code": "Visual Studio Code",
+    "vscodium": "VSCodium", "codium": "VSCodium",
+    "windsurf": "Windsurf",
+}
+
+
+def _resolve_editor(app):
+    """Map a loose editor name to the exact installed app name (unchanged if not an editor)."""
+    return _EDITOR_ALIASES.get((app or "").strip().lower(), app)
+
+
+def _is_editor(app):
+    """True if `app` names an Electron code editor we drive over CDP (Cursor/VS Code/…)."""
+    a = (app or "").strip().lower()
+    return a in _EDITOR_ALIASES or _resolve_editor(app) in _EDITOR_ALIASES.values()
+
+
+def editor_target(app):
+    """(port, profile, real_app_name) for an editor. Each editor gets its OWN dedicated Hunch
+    profile + a deterministic port, so driving it never collides with the Chrome CDP profile
+    and never touches the user's OWN editor window — a separate, focus-free Hunch instance,
+    the same non-destructive pattern Hunch uses for Chrome."""
+    real = _resolve_editor(app)
+    slug = re.sub(r"[^a-z0-9]+", "-", real.lower()).strip("-") or "editor"
+    profile = os.path.expanduser(f"~/.hunch/{slug}-cdp")
+    port = 9360 + (zlib.crc32(real.encode()) % 40)   # 9360-9399, off the browser port (9337)
+    return port, profile, real
+
+
+# Side-panel windows an editor exposes as extra page targets — bind the real editor, not these.
+# Precise titles (not bare 'agents') so a workspace folder literally named "agents" isn't excluded.
+_EDITOR_SIDE_PANELS = ("cursor agents",)
+
+
+def _pick_workbench(pages):
+    """From an editor's page targets, choose the real editor window: a workbench.html target whose
+    title is NOT a side panel (Cursor's 'Cursor Agents', etc.). Returns None if none qualify yet —
+    the workbench target can lag the side panel at startup, so callers poll on this (and fall back
+    to pages[0] only after the timeout)."""
+    wb = [p for p in (pages or []) if "workbench.html" in (p.get("url", "") or "")]
+    main = [p for p in wb if not any(s in (p.get("title", "") or "").lower() for s in _EDITOR_SIDE_PANELS)]
+    return (main or [None])[0]
+
+
 def _wait_for_port(port, timeout=15):
     """Poll the CDP HTTP endpoint until the debug port binds."""
     end = time.time() + timeout
@@ -91,7 +144,8 @@ def _clear_singleton(data_dir):
             pass
 
 
-def launch_chromium(app_name, port, url=None, background=True, isolated=False, profile=None):
+def launch_chromium(app_name, port, url=None, background=True, isolated=False, profile=None,
+                    editor=False):
     """Launch a Chromium/Electron app with CDP enabled.
       isolated=True  -> a throwaway sandbox profile (no logins).
       otherwise      -> a persistent, DEDICATED Hunch profile (HUNCH_PROFILE, or `profile`)
@@ -127,6 +181,10 @@ def launch_chromium(app_name, port, url=None, background=True, isolated=False, p
         # `open` prints "Unable to find application named 'X'" and returns non-zero when the
         # app name is wrong — surface THAT clearly instead of a misleading debug-port timeout.
         if proc.returncode != 0 or "unable to find application" in (proc.stderr or "").lower():
+            if editor:
+                raise RuntimeError(
+                    f"no editor named {app_name!r} on this Mac ({(proc.stderr or '').strip() or 'not found'}). "
+                    f"Supported editors: Cursor, Visual Studio Code, VSCodium, Windsurf.")
             raise RuntimeError(
                 f"no browser named {app_name!r} on this Mac ({(proc.stderr or '').strip() or 'not found'}). "
                 f"web_open drives a Chromium BROWSER (or Electron app) — pass a browser like "
@@ -206,16 +264,20 @@ class CDPSession:
             except Exception:
                 pass
 
-    def connect(self, timeout=10):
+    def connect(self, timeout=10, editor=False):
         end = time.time() + timeout
         pages = []
-        while time.time() < end and not pages:
+        while time.time() < end and not (pages if not editor else _pick_workbench(pages)):
             pages = self._list_page_targets()
-            if not pages:
+            if not pages or (editor and not _pick_workbench(pages)):
                 time.sleep(0.5)
         if not pages:
             raise RuntimeError(f"no CDP page target on :{self.port} — is the app launched with --remote-debugging-port?")
-        self._open_ws(pages[0])
+        # An editor exposes SEVERAL page targets that share the same workbench.html url — the real
+        # editor window AND side panels like Cursor's "Agents" (title 'Cursor Agents'). They differ
+        # only by title, so bind the editor window (has the tree + terminal), not a side panel.
+        target = _pick_workbench(pages) or pages[0] if editor else pages[0]
+        self._open_ws(target)
         self._known_targets = {p.get("id") for p in pages}
         return self
 
@@ -405,18 +467,70 @@ class CDPSession:
       return 'FALLBACK';
     }"""
 
+    # Detect (and focus) an xterm.js terminal, returning 'TERMINAL' or 'NOT_TERMINAL'. A terminal
+    # must NOT be typed via .value-setting (_SET_FN) — xterm reads keystrokes, not the textarea's
+    # value — so a match reroutes to the keystroke path. Three cases, because xterm's real input
+    # textarea is aria-hidden and does NOT appear in the a11y snapshot: the ref may be (a) that
+    # helper textarea, (b) the .xterm container / a node inside it, or (c) the only terminal handle
+    # the tree DOES expose — the "Terminal" tab/region. In case (c) we focus the ACTIVE terminal's
+    # textarea (VS Code keeps only the visible terminal's xterm in the DOM), so typing on the tab
+    # the agent can actually see still lands in the shell.
+    _XTERM_FOCUS_FN = r"""function(){
+      var el=this;
+      var term=(el.closest&&el.closest('.xterm'))
+            || ((el.classList&&el.classList.contains('xterm-helper-textarea'))?el:null)
+            || (el.querySelector&&el.querySelector('.xterm'));
+      var ta=null;
+      if(term){
+        ta=(el.classList&&el.classList.contains('xterm-helper-textarea'))?el
+          :(term.querySelector&&term.querySelector('.xterm-helper-textarea'));
+      } else {
+        var label=(((el.getAttribute&&el.getAttribute('aria-label'))||'')+' '+((el.textContent)||'')).toLowerCase();
+        if(/terminal/.test(label)) ta=document.querySelector('.xterm-helper-textarea');
+      }
+      if(!ta) return 'NOT_TERMINAL';
+      ta.focus();
+      return 'TERMINAL';
+    }"""
+
+    def _press_enter(self):
+        for t in ("keyDown", "keyUp"):
+            self._cmd("Input.dispatchKeyEvent", {"type": t, "key": "Enter", "code": "Enter",
+                      "windowsVirtualKeyCode": 13, "nativeVirtualKeyCode": 13, "text": "\r"})
+
+    def _insert_stream(self, text):
+        """Type `text` into whatever is focused, sending a real Enter for every newline. This is
+        how a terminal (and any submit-on-Enter field) receives multi-line input: printable runs
+        go in via Input.insertText, line breaks become Enter keystrokes. A trailing '\\n' SUBMITS
+        (runs the command) — so type 'claude agents\\n' to start it, or omit the '\\n' to stage it."""
+        segs = text.split("\n")
+        for idx, seg in enumerate(segs):
+            if seg:
+                self._cmd("Input.insertText", {"text": seg})
+            if idx < len(segs) - 1:
+                self._press_enter()
+
     def type_text(self, ref, text):
         """Fill a field, REPLACING its content. Works for text inputs, textareas, and native
-        <select> dropdowns (matches an option by visible text/value). Falls back to focus +
+        <select> dropdowns (matches an option by visible text/value). An xterm.js TERMINAL
+        (Cursor/VS Code integrated terminal) is detected and typed via real keystrokes into the
+        PTY (newlines become Enter — a trailing newline runs the command). Falls back to focus +
         select-all + insertText for contenteditable / rich editors."""
         if not ref:
-            self._cmd("Input.insertText", {"text": text})
+            self._insert_stream(text)
             return f"typed {len(text)} chars at focus"
         backend = self.registry.get(ref)
         if backend is None:
             raise KeyError(f"stale ref {ref}")
         obj = self._cmd("DOM.resolveNode", {"backendNodeId": backend}).get("object", {}).get("objectId")
         if obj:
+            kind = (self._cmd("Runtime.callFunctionOn",
+                              {"objectId": obj, "functionDeclaration": self._XTERM_FOCUS_FN,
+                               "returnByValue": True}).get("result", {}).get("value", ""))
+            if kind == "TERMINAL":
+                self._insert_stream(text)
+                ran = " (ran it)" if text.endswith("\n") else " (staged — no trailing newline)"
+                return f"{ref}: typed into the terminal as real keystrokes{ran}"
             res = (self._cmd("Runtime.callFunctionOn",
                              {"objectId": obj, "functionDeclaration": self._SET_FN,
                               "arguments": [{"value": text}], "returnByValue": True})
@@ -466,7 +580,12 @@ class CDPSession:
     _KEYS = {"return": ("Enter", 13), "enter": ("Enter", 13), "tab": ("Tab", 9),
              "escape": ("Escape", 27), "backspace": ("Backspace", 8), "delete": ("Delete", 46),
              "up": ("ArrowUp", 38), "down": ("ArrowDown", 40),
-             "left": ("ArrowLeft", 37), "right": ("ArrowRight", 39), "space": (" ", 32)}
+             "left": ("ArrowLeft", 37), "right": ("ArrowRight", 39), "space": (" ", 32),
+             # backtick: needed for ctrl+` — the toggle that opens an editor's integrated terminal
+             "`": ("`", 192), "backtick": ("`", 192), "backquote": ("`", 192)}
+    # DOM `code` for keys whose code != the derived Key*/Digit* (punctuation shortcuts). Without
+    # the right code, VS Code/Cursor keybindings (which match on code) won't fire.
+    _CODES = {"`": "Backquote"}
     # CDP modifier bitmask (Input.dispatchKeyEvent): Alt=1, Ctrl=2, Meta/Cmd=4, Shift=8
     _MODBITS = {"alt": 1, "option": 1, "ctrl": 2, "control": 2,
                 "meta": 4, "cmd": 4, "command": 4, "super": 4, "win": 4, "shift": 8}
@@ -479,6 +598,7 @@ class CDPSession:
         if code == 0 and len(k) == 1 and k.isalnum():
             code = ord(k.upper())
             codefield = ("Key" + k.upper()) if k.isalpha() else ("Digit" + k)
+        codefield = self._CODES.get(k, codefield)
         mods = 0
         for m in (modifiers or []):
             mods |= self._MODBITS.get(str(m).lower(), 0)
@@ -597,15 +717,17 @@ class CDPComputer:
     but for the whole Chromium/Electron category, in the background."""
 
     def __init__(self, app, port=9333, url=None, isolated=False, background=True,
-                 connect=True, profile=None):
+                 connect=True, profile=None, editor=False):
         self.app = app
         self.port = port
+        self.editor = editor
         self.tools = CDP_TOOLS
         self.session = None
         if connect:
             launch_chromium(app, port, url=url, background=background, isolated=isolated,
-                            profile=profile)
-            self.session = CDPSession(port).connect()
+                            profile=profile, editor=editor)
+            # editors expose several page targets — bind the workbench (holds the tree + terminal)
+            self.session = CDPSession(port).connect(editor=editor)
 
     def snapshot(self):
         return self.session.snapshot()[0]

--- a/src/hunch/local_mac.py
+++ b/src/hunch/local_mac.py
@@ -55,6 +55,28 @@ def _embedded_chromium(pid):
     return None
 
 
+def _is_editor_terminal(el, pid):
+    """True if `el` is an integrated TERMINAL inside an embedded-Chromium editor (Cursor,
+    VS Code, …). Such terminals are xterm.js: they read real KEYSTROKES off a hidden helper
+    textarea, so an AX value-set lands in xterm's screen-reader MIRROR and never reaches the
+    PTY — the set 'succeeds' (returns 0) while nothing runs. We detect it so set_text refuses
+    honestly and steers to the CDP path instead of reporting a phantom success. Narrow by
+    design: only fires inside Electron/CEF apps, only on text elements, only when the AX name
+    is xterm's 'Terminal N, …' label — so a normal Electron input (Slack, etc.) is untouched."""
+    if not _embedded_chromium(pid):
+        return False
+    try:
+        a = ax.get_attrs(el, (ax.kAXRoleAttribute, ax.kAXTitleAttribute, ax.kAXDescriptionAttribute))
+        role = str(a.get(ax.kAXRoleAttribute) or "")
+        if role not in ("AXTextArea", "AXTextField"):
+            return False
+        label = f"{a.get(ax.kAXTitleAttribute) or ''} {a.get(ax.kAXDescriptionAttribute) or ''}".lower()
+    except Exception:
+        return False
+    # xterm labels the terminal "Terminal <n>, <shell/title>" (verified: "Terminal 1, zsh").
+    return bool(re.search(r"\bterminal\b", label))
+
+
 # ── forcing an embedded-Chromium app's tree to persist in the BACKGROUND ──────────────────
 # Verified 2026-07-18 on Discord (hardened Electron — strips --remote-debugging-port so CDP can't
 # attach): Chromium builds its web-content AX tree only while the app is active and TEARS IT DOWN on
@@ -818,6 +840,16 @@ class MacSession:
         keystrokes only if the field isn't AX-settable AND allow_keystrokes (typing
         uses the shared keyboard)."""
         el = self._el(ref)
+        # An integrated terminal (Cursor/VS Code) is xterm.js: an AX value-set writes into its
+        # screen-reader mirror and NEVER reaches the shell, yet returns 0 (success). Refuse that
+        # phantom success and steer to the CDP path, which types real keystrokes into the PTY.
+        if _is_editor_terminal(el, getattr(self, "_pid", None)):
+            app = self._app_name or "the editor"
+            return (f"{ref} is a terminal inside {app} — AX cannot write to it. xterm.js reads "
+                    f"keystrokes, not AX values, so an AX set would silently do nothing (it lands "
+                    f"in the screen-reader mirror, not the shell). Type into it FOCUS-FREE over "
+                    f"CDP instead: web_open(app=\"{app}\") then web_act a 'type' action on the "
+                    f"terminal — that injects real keystrokes into the PTY.")
         if AXUIElementSetAttributeValue(el, kAXValueAttribute, text) == 0:
             return f"set text on {ref}"
         if not allow_keystrokes:

--- a/src/hunch/playbook.py
+++ b/src/hunch/playbook.py
@@ -74,6 +74,17 @@ KEY WORKFLOWS:
   `screenshot` tool to see a web page — it captures the physical frontmost screen, so on a background
   CDP window you get the USER's own window, not the page. If you truly need the page as pixels
   (chart/canvas/image), use `web_screenshot` (focus-free, captures the CDP page itself).
+- Drive a code editor's TERMINAL (Cursor / VS Code): the AX tree can READ an integrated terminal
+  but CANNOT type into it — it's xterm.js, which reads real KEYSTROKES, so an AX `type` lands in a
+  screen-reader mirror and silently does nothing (snapshot's set 'succeeds' but the shell never runs
+  it). Use CDP: `web_open(app="Cursor", url="/abs/path/to/folder")` opens a DEDICATED, background
+  Hunch editor window on that folder — SEPARATE from the user's own editor, so it's non-destructive
+  and focus-free. If no terminal is open yet, `web_act` [{"action":"key","key":"`","modifiers":
+  ["ctrl"]}] to open one (it's a toggle — only if the snapshot shows no Terminal). Then `web_snapshot`,
+  find the `[eN] tab "Terminal"` element, and `web_act` "type" ref=eN text="claude agents\n": a
+  TRAILING NEWLINE runs the command in the shell; omit it to stage without running. The dedicated
+  editor profile is fresh on first use — if it shows a sign-in/onboarding wall, treat it like
+  `web_login` (have the user sign into that window once; it persists).
 - You need the human (sign-in, 2FA, a decision, review-before-submit): call `notify_user(msg)`
   so they get a desktop alert — never stall silently.
 - APP RESISTS EVERY LAYER: `snapshot` already auto-relaunches an embedded-Chromium app with the

--- a/src/hunch/sdk.py
+++ b/src/hunch/sdk.py
@@ -350,7 +350,15 @@ class Web:
         """Open a Chromium browser (or Electron app) for focus-free control. Uses the
         persistent, dedicated Hunch profile (isolated=True: throwaway sandbox profile).
         If the profile isn't signed into the site, the returned string says so — call
-        login() once, then reopen."""
+        login() once, then reopen.
+
+        For a code editor (app="Cursor"/"Visual Studio Code"/…), `url` is the FOLDER or FILE
+        to open, and Hunch drives a DEDICATED editor window (its own profile+port, separate
+        from your own editor). Its integrated terminal is then typeable focus-free via act()
+        — the AX tree can't write xterm.js, but CDP injects real keystrokes into the PTY."""
+        from .cdp import _is_editor
+        if _is_editor(app):
+            return self._open_editor(folder=url, app=app)
         import os as _os
         force = (self.force_sandbox if self.force_sandbox is not None
                  else _os.environ.get("HUNCH_FORCE_SANDBOX") == "1")
@@ -375,6 +383,34 @@ class Web:
                     "in a clearly-marked window; afterwards the profile stays logged in.")
         snap = self._computer.snapshot()
         return f"opened {app} over CDP ({snap.count('[e')} elements visible), focus-free"
+
+    def _open_editor(self, folder="", app="Cursor"):
+        """Open a code editor (Cursor/VS Code/…) on `folder` in a DEDICATED, background Hunch
+        window and drive it over CDP. Non-destructive: it's a separate instance on its own
+        profile+port, so the user's own editor is untouched. The integrated terminal becomes
+        focus-free-typeable (act 'type' on the terminal element, or key ctrl+` to open one)."""
+        import os as _os
+        from .cdp import CDPComputer, editor_target
+        port, profile, real = editor_target(app)
+        _os.makedirs(profile, exist_ok=True)
+        self.close()
+        try:
+            self._computer = CDPComputer(real, port=port, url=folder or None,
+                                         isolated=False, background=True, profile=profile,
+                                         editor=True)
+        except Exception as e:
+            raise HunchError(f"couldn't open {real} over CDP: {e} — "
+                             "web.restart() recovers a stale instance") from e
+        s = self._computer.session
+        s.wait_ready()
+        snap = self._computer.snapshot()
+        where = f" on {folder}" if folder else ""
+        has_term = ".xterm" in snap or "xterm-helper" in snap
+        tip = ("Its terminal is open — act a 'type' on the terminal element to run commands "
+               "focus-free." if has_term else
+               "No terminal open yet — act key ctrl+` to open one, web_snapshot, then 'type' into it.")
+        return (f"opened {real}{where} over CDP ({snap.count('[e')} elements), focus-free — a "
+                f"dedicated Hunch editor window, separate from your own. {tip}")
 
     def login(self, url="", app="Google Chrome"):
         """Open a background, banner-tagged window for the HUMAN to sign in once (Hunch

--- a/src/hunch/server.py
+++ b/src/hunch/server.py
@@ -232,7 +232,14 @@ def web_open(app: str = "Google Chrome", url: str = "", isolated: bool = False) 
     isolated=True gives a throwaway sandbox profile (no logins). Default uses a persistent,
     DEDICATED Hunch profile — NOT the user's real/default profile (modern Chrome refuses the
     debug port there). If that Hunch profile isn't logged into the site yet, this returns a
-    prompt to call web_login once; after that the session persists and stays focus-free."""
+    prompt to call web_login once; after that the session persists and stays focus-free.
+
+    CODE EDITORS: pass app="Cursor" / "Visual Studio Code" / "VSCodium" / "Windsurf" and put the
+    FOLDER or FILE to open in `url`. This drives a DEDICATED, background Hunch editor window
+    (separate from the user's own editor), letting you type into its integrated TERMINAL — which
+    the AX tree can read but never write. After opening: web_snapshot, then web_act a 'type' on the
+    `[eN] tab "Terminal"` element (a trailing "\\n" runs the command); key ctrl+` opens a terminal
+    if none is shown."""
     return _run("web_open", app=app, url=url, isolated=isolated)
 
 

--- a/tests/test_editor_terminal.py
+++ b/tests/test_editor_terminal.py
@@ -1,0 +1,176 @@
+"""Tests for the focus-free editor-terminal path.
+
+Two halves:
+  1. The honest-failure guard in local_mac.set_text — an AX value-set into an editor's
+     xterm.js terminal LOOKS like it succeeds (returns 0) but never reaches the PTY, so
+     set_text must detect that case and refuse instead of reporting a phantom success.
+  2. The CDP editor plumbing (cdp.py) — editor detection, dedicated port/profile, and the
+     xterm-aware typing that routes a terminal 'type' through Input.insertText keystrokes
+     rather than .value-setting (which xterm ignores).
+
+Dependency-light: no live editor, no CDP socket — the AX and CDP calls are stubbed.
+"""
+
+import sys
+
+import hunch.cdp as cdp
+import hunch.local_mac as local_mac
+from hunch import ax_tree_mac as ax
+
+
+# ── 1. honest-failure guard ────────────────────────────────────────────────────
+def _fake_attrs(role, title="", desc=""):
+    return {ax.kAXRoleAttribute: role, ax.kAXTitleAttribute: title, ax.kAXDescriptionAttribute: desc}
+
+
+def test_is_editor_terminal_detects_xterm(monkeypatch):
+    monkeypatch.setattr(local_mac, "_embedded_chromium", lambda pid: "Electron Framework.framework")
+    monkeypatch.setattr(ax, "get_attrs", lambda el, attrs: _fake_attrs("AXTextArea", "Terminal 1, zsh"))
+    assert local_mac._is_editor_terminal(object(), 123) is True
+
+
+def test_is_editor_terminal_ignores_plain_electron_input(monkeypatch):
+    # A normal Electron text box (Slack message, etc.) must NOT be misread as a terminal.
+    monkeypatch.setattr(local_mac, "_embedded_chromium", lambda pid: "Electron Framework.framework")
+    monkeypatch.setattr(ax, "get_attrs", lambda el, attrs: _fake_attrs("AXTextArea", "Message #general"))
+    assert local_mac._is_editor_terminal(object(), 123) is False
+
+
+def test_is_editor_terminal_ignores_native_apps(monkeypatch):
+    # Not embedded-Chromium -> never a terminal-guard case, even if named "Terminal".
+    monkeypatch.setattr(local_mac, "_embedded_chromium", lambda pid: None)
+    monkeypatch.setattr(ax, "get_attrs", lambda el, attrs: _fake_attrs("AXTextArea", "Terminal 1, zsh"))
+    assert local_mac._is_editor_terminal(object(), 123) is False
+
+
+def test_is_editor_terminal_requires_text_role(monkeypatch):
+    monkeypatch.setattr(local_mac, "_embedded_chromium", lambda pid: "Electron Framework.framework")
+    monkeypatch.setattr(ax, "get_attrs", lambda el, attrs: _fake_attrs("AXButton", "Terminal"))
+    assert local_mac._is_editor_terminal(object(), 123) is False
+
+
+def test_set_text_refuses_editor_terminal(monkeypatch):
+    """set_text must NOT claim success on a terminal — it must return a refusal that points
+    to the CDP path, and must never call AXUIElementSetAttributeValue."""
+    sess = local_mac.MacSession()
+    sess._app_name, sess._pid = "Cursor", 999
+    monkeypatch.setattr(sess, "_el", lambda ref: object())
+    monkeypatch.setattr(local_mac, "_is_editor_terminal", lambda el, pid: True)
+
+    called = {"set": False}
+
+    def _boom(*a, **k):
+        called["set"] = True
+        return 0
+    monkeypatch.setattr(local_mac, "AXUIElementSetAttributeValue", _boom)
+
+    msg = sess.set_text("e100", "claude agents\n")
+    assert called["set"] is False, "must not attempt the phantom AX set"
+    assert "terminal" in msg.lower() and "web_open" in msg
+    assert "set text on" not in msg
+
+
+# ── 2. CDP editor plumbing ─────────────────────────────────────────────────────
+def test_editor_detection():
+    for name in ("Cursor", "cursor", "code", "vscode", "VS Code", "windsurf", "vscodium"):
+        assert cdp._is_editor(name), name
+    for name in ("Google Chrome", "Arc", "Discord", "", "Safari"):
+        assert not cdp._is_editor(name), name
+
+
+def test_editor_target_is_dedicated_and_stable():
+    port, profile, real = cdp.editor_target("cursor")
+    assert real == "Cursor"
+    assert "cursor-cdp" in profile
+    assert 9360 <= port <= 9399         # off the browser port (9337)
+    assert port != cdp.editor_target("code")[0] or real != "Visual Studio Code"
+    # deterministic
+    assert cdp.editor_target("cursor")[0] == port
+
+
+def test_pick_workbench_skips_agents_side_panel():
+    """An editor exposes the real window AND side panels sharing the same workbench.html url;
+    they differ only by title. _pick_workbench must bind the editor, not 'Cursor Agents'."""
+    wb = "vscode-file://vscode-app/.../electron-sandbox/workbench/workbench.html"
+    pages = [
+        {"id": "1", "title": "Cursor Agents", "url": wb},
+        {"id": "2", "title": "my-project — Cursor", "url": wb},
+    ]
+    assert cdp._pick_workbench(pages)["id"] == "2"
+    # order-independent
+    assert cdp._pick_workbench(list(reversed(pages)))["id"] == "2"
+    # only the side panel is up yet -> None (caller keeps polling for the real window)
+    assert cdp._pick_workbench([pages[0]]) is None
+    assert cdp._pick_workbench([]) is None
+
+
+class _RecordingSession(cdp.CDPSession):
+    """A CDPSession that records CDP commands instead of hitting a socket, and answers the
+    xterm-detection probe as configured."""
+    def __init__(self, is_terminal):
+        self.calls = []
+        self._is_terminal = is_terminal
+        self.registry = {"e5": 42}
+
+    def _cmd(self, method, params=None, timeout=20):
+        self.calls.append((method, params or {}))
+        if method == "DOM.resolveNode":
+            return {"object": {"objectId": "obj-1"}}
+        if method == "Runtime.callFunctionOn":
+            fn = (params or {}).get("functionDeclaration", "")
+            if "xterm-helper-textarea" in fn:      # the _XTERM_FOCUS_FN probe
+                return {"result": {"value": "TERMINAL" if self._is_terminal else "NOT_TERMINAL"}}
+            return {"result": {"value": "set"}}     # the _SET_FN path
+        return {}
+
+
+def test_terminal_type_uses_keystrokes_not_value_set():
+    """Typing into a terminal ref must go through Input.insertText + an Enter keystroke for the
+    trailing newline, and must NOT set the textarea .value (which xterm ignores)."""
+    s = _RecordingSession(is_terminal=True)
+    out = s.type_text("e5", "claude agents\n")
+    methods = [m for m, _ in s.calls]
+    assert "Input.insertText" in methods
+    inserted = [p["text"] for m, p in s.calls if m == "Input.insertText"]
+    assert inserted == ["claude agents"]            # newline stripped, sent as Enter
+    enters = [p for m, p in s.calls if m == "Input.dispatchKeyEvent" and p.get("key") == "Enter"]
+    assert enters, "trailing newline must become an Enter keystroke (run the command)"
+    assert "ran it" in out
+    # only the xterm probe should have run — never the .value-setting _SET_FN
+    fns = [p.get("functionDeclaration", "") for m, p in s.calls if m == "Runtime.callFunctionOn"]
+    assert len(fns) == 1 and "xterm-helper-textarea" in fns[0]
+
+
+def test_nonterminal_type_still_sets_value():
+    """A normal field must still use the .value-setting path, not the terminal keystroke path."""
+    s = _RecordingSession(is_terminal=False)
+    out = s.type_text("e5", "hello")
+    fns = [p.get("functionDeclaration", "") for m, p in s.calls if m == "Runtime.callFunctionOn"]
+    assert any("HTMLTextAreaElement" in f or "FALLBACK" in f for f in fns), "should reach _SET_FN"
+    assert "e5: set" in out
+
+
+def test_insert_stream_splits_newlines():
+    s = _RecordingSession(is_terminal=True)
+    s.calls = []
+    s._insert_stream("line1\nline2\n")
+    inserts = [p["text"] for m, p in s.calls if m == "Input.insertText"]
+    enter_downs = [1 for m, p in s.calls
+                   if m == "Input.dispatchKeyEvent" and p.get("key") == "Enter" and p["type"] == "keyDown"]
+    assert inserts == ["line1", "line2"]
+    assert len(enter_downs) == 2         # one Enter per newline (each = a keyDown+keyUp pair)
+
+
+def test_backtick_key_has_backquote_code():
+    """ctrl+` (open terminal) needs DOM code 'Backquote' or the editor keybinding won't fire."""
+    s = _RecordingSession(is_terminal=True)
+    s.calls = []
+    s.press_key("`", ["ctrl"])
+    downs = [p for m, p in s.calls if m == "Input.dispatchKeyEvent"]
+    assert downs and all(p["code"] == "Backquote" for p in downs)
+    assert all(p["modifiers"] == 2 for p in downs)   # ctrl bit
+
+
+if __name__ == "__main__":
+    import pytest
+    sys.exit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Problem

Hunch could not type into an editor's integrated terminal. The AX tree can **read** it but never **write** it: the terminal is xterm.js, which reads real keystrokes off a hidden helper `<textarea>`, so an `AXValue` set lands in the screen-reader mirror and **returns success while nothing reaches the PTY** — a silent phantom success (the exact failure that stranded a real session).

## Fix

**1. Stop the lie.** `local_mac.set_text` now detects an xterm terminal inside an embedded-Chromium editor and refuses honestly, pointing to the CDP path, instead of reporting `set text on …` for a write that never happened.

**2. A CDP path that actually works.** `web_open(app="Cursor", url="/folder")` opens a **dedicated, background Hunch editor window** — its own profile + port, separate from the user's own editor (non-destructive, same pattern Hunch uses for Chrome). Its terminal is then typeable: `web_snapshot` → `web_act` a `type` on the `[eN] tab "Terminal"` element → real keystrokes to the PTY (trailing `\n` runs the command; `ctrl+\`` opens one).

## Changes
- `local_mac.py` — `_is_editor_terminal` guard in `set_text`
- `cdp.py` — editor aliases, `editor_target` (dedicated profile/port), `_pick_workbench` (skips the "Cursor Agents" side panel — both share `workbench.html`, differ only by title), xterm-aware `type_text` / `_XTERM_FOCUS_FN`, backtick key
- `sdk.py` — `Web._open_editor`
- `playbook.py` + `web_open` tool docs — the editor-terminal workflow

## Verification

Every load-bearing assumption was spiked against a real Cursor (Electron 40 / Chrome 144), not assumed:
- Cursor **binds** `--remote-debugging-port` (the original blocker was only the missing flag)
- CDP `Input.insertText` + Enter into the focused xterm **runs commands in the PTY**
- The real `CDPComputer.act` path types into the terminal tab ref and the command runs — confirmed on a live signed-in window

Also verified: command palette / dialogs render in the same CDP target (seen automatically); a new editor window is a separate target (reachable via `web_tabs`/`web_switch_tab`).

## Tests
- New `tests/test_editor_terminal.py` (12 tests): honest-failure guard, editor detection, `_pick_workbench`, xterm typing routing, backtick code.
- Full suite: 107 passed, 1 pre-existing failure (`test_screen_approval_dedupe`, an environment flake identical on `main`).
- No new MCP tool — `test_tool_count` stays 29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)