### PR TITLE
feat: unified LLM provider abstraction + OpenAI Codex (0.6.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ macOS 13+. From PyPI (the distribution is `hunch-sdk`; the import and CLI are `h
 
 ```
 pipx install hunch-sdk          # or: pip install hunch-sdk
-pip install 'hunch-sdk[agent]'  # + the optional LLM agent loop (both backends;
-                                #   [api] or [subscription] picks just one)
+pip install 'hunch-sdk[subscription]'    # + the agent loop on Claude   (provider="claude")
+pip install --pre 'hunch-sdk[codex]'     # + the agent loop on OpenAI Codex (provider="codex")
 ```
 
 Or via Homebrew — best if you don't manage Python environments; it bundles an isolated
@@ -148,82 +148,83 @@ Runnable scripts live in [`examples/`](examples/).
 ## Agent loop (`mac.agent`)
 
 The instance SDK gives you deterministic primitives. The **agent loop** puts an LLM in the driver's seat:
-you hand it a task in plain English and Claude drives the Mac through those same primitives —
-Scrapybara's `act()`, but on *your* machine with *your* logged-in apps. It's an optional extra
-(keeps the base install free of the model SDKs):
+you hand it a task in plain English and it drives the Mac through those same primitives — on *your*
+machine with *your* logged-in apps. Pick your **provider** — Anthropic **Claude** or OpenAI **Codex** —
+once at construction; everything after is provider-agnostic. It's an optional extra (keeps the base
+install free of the model SDKs):
 
 ```bash
-pip install 'hunch-sdk[agent]'
-python -c 'import hunch; hunch.login()'   # Claude subscription sign-in (browser OAuth) — no
-                                          # API key. Already signed into Claude Code? Skip it.
+pip install 'hunch-sdk[subscription]'                    # Claude
+# or, for Codex (the SDK is beta):  pip install --pre 'hunch-sdk[codex]'
+python -c 'import hunch; hunch.provider("claude").login()'   # sign-in (browser OAuth) — no API key
 ```
 
 ```python
 from hunch import Hunch
 
-mac = Hunch()
+mac = Hunch(provider="claude")          # or Hunch(provider="codex")
 result = mac.agent.run("reply to Sarah's latest email, but don't send it")
-print(result.text)          # Claude's final summary
+print(result.text)          # the model's final summary
 print(result.turns, result.usage)
 ```
 
 ### Signing in
 
-Auth is an explicit, visible surface — nothing is scavenged silently. Two ways to run the loop:
-
-| Backend | Sign in with | Cost |
-|---|---|---|
-| `subscription` | `hunch.login()` — the same browser OAuth Claude Code uses. Already signed into Claude Code on this Mac? You're done; Hunch reuses that. | your Claude plan (no per-token cost) |
-| `api` | `export ANTHROPIC_API_KEY=sk-ant-...` | metered API tokens |
-
-You choose the backend where it suits your code — at construction, or per call:
+Auth is an explicit, provider-scoped surface — nothing is scavenged silently. You choose the vendor
+once, then the same prefix-free methods act on it:
 
 ```python
-mac = Hunch(agent_backend="subscription")            # this instance's agent = subscription
-mac.agent.run(task)                                  # ...no per-call ceremony
-mac.agent.run(other_task, backend="api")             # per-call override still wins
+mac = Hunch(provider="codex")       # or "claude" (the default)
+mac.login()                         # codex: ChatGPT browser sign-in · claude: Claude sign-in
+mac.status()                        # -> AuthStatus(provider, logged_in, method, email, plan)
+mac.logout()
+mac.agent.run(task)                 # runs on the configured provider
 ```
 
-The default `backend="auto"` picks by credentials, in a fixed documented order (API key →
-`CLAUDE_CODE_OAUTH_TOKEN` env → Claude Code sign-in → `hunch.login(token=...)` token) — inspect
-it any time with `hunch.auth.status()` or `hunch doctor`. With no credentials at all, `run()`
-raises a `HunchError` naming both fixes — it never guesses.
-
-Auth is **public Python API** (there is no login CLI — the MCP server never needs one, and your
-app owns its own onboarding):
+Or drive auth standalone, without a Mac instance (e.g. an onboarding script):
 
 ```python
 import hunch
 
-st = hunch.auth.status()           # AuthStatus: .source / .email / .plan / .subscription_ready
-if not st.subscription_ready:
-    hunch.login()                  # browser OAuth; or hunch.login(token="sk-ant-oat-...") headless
-hunch.logout()                     # removes what login() stored, and only that
+st = hunch.provider("codex").status()
+if not st.logged_in:
+    hunch.provider("codex").login()               # browser OAuth (blocks until done)
+    # headless/remote box instead:
+    #   h = hunch.provider("codex").device_login()
+    #   print(h.verification_url, h.user_code); h.wait()
 ```
 
-- **Watch it work** with an `on_event(kind, data)` callback — `kind` is one of `text` (Claude's
-  reasoning), `tool` (`{name, input}`), `tool_result` (preview), `done` (final text), `error`.
-- **Continuation**: follow-up `run()` calls keep the conversation (Claude still knows which email
+| Provider | Sign in with | Cost |
+|---|---|---|
+| `claude` | `mac.login()` / `hunch.provider("claude").login()` — the same browser OAuth Claude Code uses. Already signed into Claude Code on this Mac? You're done; Hunch reuses that. | your Claude plan (no per-token cost) |
+| `codex` | `mac.login()` / `codex login` — a ChatGPT/Codex browser sign-in. | your ChatGPT/Codex plan |
+
+Both run on a subscription/login — metered API keys are intentionally not exposed. With no valid
+sign-in, `run()` surfaces an error that points you back to `login()` — it never guesses.
+
+- **Watch it work** with an `on_event(kind, data)` callback — `kind` is one of `text` (reasoning),
+  `tool` (`{name, input}`), `tool_result` (preview), `done` (final text), `error`.
+- **Continuation**: follow-up `run()` calls keep the conversation (the model still knows which email
   is Sarah's); `mac.agent.reset()` starts a fresh task.
 - **Mix layers freely**: call `mac.snapshot(...)` / `mac.clipboard.get()` deterministically around
   `mac.agent.run(...)` — the thing a cloud sandbox can't do on your real machine.
-- **Knobs**: `run(task, model=None, max_turns=40, effort=None, on_event=None,
-  system_suffix="", backend=None)` — `model=None` means `claude-opus-4-8` on the api backend and
-  your subscription's default model otherwise. `AgentResult` has `text`, `turns`, `stop_reason`,
-  `usage`, `aborted`.
+- **Knobs**: `run(task, model=None, max_turns=40, effort=None, on_event=None, system_suffix="")` —
+  `model=None` uses the provider's own default model. `AgentResult` has `text`, `turns`,
+  `stop_reason`, `usage`, `aborted`.
 - **Safety**: the instance's gate config governs the loop. The default `confirm="dialog"` pops a
   real "Go ahead?" dialog before any focus-stealing or risky step — good when you're at the
   machine, but a gated action can stall an unattended run for the dialog's timeout. For cron jobs
-  use `Hunch(confirm="off")` and accept the risk; Claude still asks *you* (via `notify_user`)
-  before irreversible or outward actions like sending a message. A declined gate comes back to the
-  model as a `REFUSED` result, so the loop adapts instead of crashing.
-- **Cost**: on the subscription backend, runs draw on your Claude plan's usage limits — no
-  per-token bill. On the api backend each turn resends the tree-heavy history; prompt caching is
-  on by default, so cached input is ~10× cheaper — but long autonomous runs still add up.
-  `max_turns` caps it either way.
+  use `Hunch(confirm="off")` and accept the risk; the model still asks *you* (via `notify_user`)
+  before irreversible or outward actions. A declined gate comes back as a `REFUSED` result, so the
+  loop adapts instead of crashing.
+- **Cost**: runs draw on your provider plan's usage limits — no per-token bill. `max_turns` caps it.
 
-Other models: the agent loop is Claude-only, but the instance-SDK primitives are provider-agnostic —
-wire `mac.snapshot()` / `mac.act()` into your own OpenAI/Gemini/etc. agent loop as tools.
+> **Codex note:** the `codex` provider drives an OpenAI Codex agent that reaches Hunch's tools over
+> MCP (a separate `hunch serve` process), so its dangerous-verb approvals use Hunch's own
+> click-to-approve dialogs rather than a host `can_use_tool` callback.
+
+Other models: the instance-SDK primitives are provider-agnostic — wire `mac.snapshot()` /
+`mac.act()` into your own OpenAI/Gemini/etc. agent loop as tools.
 
 ## Building an app on Hunch
 
@@ -236,6 +237,7 @@ profile) is nothing but constructor arguments.
 from hunch import Hunch, ConsentRequest, OAuthToken
 
 mac = Hunch(
+    provider="claude",                  # which LLM vendor drives mac.agent ("claude" | "codex")
     app_id="com.acme.mailbot",          # pure namespacing — own Keychain slots, browser
                                         #   profile, and CDP port; never a behavior switch
     app_name="Acme Mailbot",            # what consent dialogs + notifications say
@@ -243,8 +245,8 @@ mac = Hunch(
     notify=my_toast_handler,            # (message, title) -> your surface, not macOS banners
     policy={"gates": {"shell": True}},  # instance-owned safety; the user's personal
                                         #   config can never disarm your app
-    auth=OAuthToken(token),             # exactly the credential YOUR app manages —
-                                        #   or "none" to forbid ambient pickup entirely
+    auth=OAuthToken(token),             # the exact Claude subscription token YOUR app manages
+    can_use_tool=my_approver,           # optional: route every tool through your Approve/Deny UI
 )
 ```
 
@@ -258,9 +260,9 @@ What this buys you:
   dialogs and macOS banners. A broken consent callback fails **closed**.
 - **Isolated safety posture** — the machine's `hunch config` (and `HUNCH_NO_INTERNAL_GATE`)
   govern only the personal MCP server, never your instance.
-- **Explicit auth** — `hunch.ApiKey(...)` / `hunch.OAuthToken(...)` use exactly that credential
-  (reprs are redacted); `auth="none"` guarantees your app never silently rides on the end
-  user's own Claude sign-in.
+- **Explicit auth** — `provider="claude"` with `auth=hunch.OAuthToken(...)` uses exactly that
+  subscription token (reprs are redacted), so your app never silently rides on the end user's own
+  Claude sign-in. (The `codex` provider authenticates via `mac.login()` / `codex login`.)
 
 Programmatic credential management uses the same namespacing: `hunch.creds.set_credential(name,
 user, pw, namespace=your_app_id)` etc. A runnable walkthrough lives in

--- a/examples/agent_task.py
+++ b/examples/agent_task.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python3
 """Run one natural-language task on this Mac with the Hunch agent loop.
 
-    pip install 'hunch-sdk[agent]'
-    python -c 'import hunch; hunch.login()'    # Claude subscription (no API key), or:
-    export ANTHROPIC_API_KEY=sk-ant-...        # metered API
+    pip install 'hunch-sdk[subscription]'                        # Claude
+    python -c 'import hunch; hunch.provider("claude").login()'   # sign in (no API key)
     python examples/agent_task.py "open Music and play my Focus playlist"
 
 Signed into Claude Code on this Mac already? Skip the login line — it's picked up.
+For OpenAI Codex: pip install --pre 'hunch-sdk[codex]', run `codex login`, then pass
+`--provider codex`.
 
-Your terminal/IDE needs the Accessibility permission (System Settings → Privacy &
-Security → Accessibility). By default Claude asks before any focus-stealing or
+Your terminal/IDE needs the Accessibility permission (System Settings -> Privacy &
+Security -> Accessibility). By default the model asks before any focus-stealing or
 irreversible step (a real dialog); pass --unattended to auto-approve for scripts.
 """
 import argparse
@@ -20,10 +21,10 @@ from hunch import Hunch
 def main():
     p = argparse.ArgumentParser()
     p.add_argument("task")
-    p.add_argument("--backend", default="auto", choices=["auto", "api", "subscription"],
-                   help="auto picks by credentials — see hunch.auth.status()")
+    p.add_argument("--provider", default="claude", choices=["claude", "codex"],
+                   help="which LLM vendor drives the loop")
     p.add_argument("--model", default=None,
-                   help="default: claude-opus-4-8 (api) / your subscription's model")
+                   help="default: the provider's own model")
     p.add_argument("--max-turns", type=int, default=40)
     p.add_argument("--effort", default=None, help="low | medium | high | xhigh | max")
     p.add_argument("--unattended", action="store_true",
@@ -32,7 +33,7 @@ def main():
 
     def on_event(kind, data):
         if kind == "text":
-            print(f"\nclaude: {data}")
+            print(f"\n{args.provider}: {data}")
         elif kind == "tool":
             print(f"  → {data['name']}({data['input']})")
         elif kind == "tool_result":
@@ -42,13 +43,11 @@ def main():
         elif kind == "error":
             print(f"\n✗ {data}")
 
-    mac = Hunch(confirm="off" if args.unattended else "dialog")
+    mac = Hunch(provider=args.provider, confirm="off" if args.unattended else "dialog")
     try:
         result = mac.agent.run(args.task, model=args.model, max_turns=args.max_turns,
-                               effort=args.effort, on_event=on_event, backend=args.backend)
-        print(f"\n— {result.turns} turns, stop_reason={result.stop_reason}, "
-              f"tokens in/out={result.usage.get('input_tokens')}/{result.usage.get('output_tokens')} "
-              f"(cached read {result.usage.get('cache_read_input_tokens')})")
+                               effort=args.effort, on_event=on_event)
+        print(f"\n— {result.turns} turns, stop_reason={result.stop_reason}, usage={result.usage}")
     finally:
         mac.close()
 

--- a/examples/embedded_app.py
+++ b/examples/embedded_app.py
@@ -26,6 +26,7 @@ def toast(message: str, title: str) -> None:
 
 
 mac = Hunch(
+    provider="claude",                  # which LLM vendor drives mac.agent ("claude" | "codex")
     app_id="com.example.demoapp",       # pure namespacing: own Keychain slots, own
                                         #   browser profile, own derived CDP port
     app_name="Demo App",                # what consent prompts + notifications say
@@ -33,16 +34,15 @@ mac = Hunch(
     notify=toast,                       # notifications go through YOUR surface
     policy={"gates": {"shell": True}},  # instance-owned safety; the user's personal
                                         #   ~/.hunch/config.json is never consulted
-    auth="none",                        # never scavenge ambient credentials; swap in
-                                        #   auth=OAuthToken("sk-ant-oat-...") or
-                                        #   hunch.ApiKey("sk-ant-...") that YOUR app manages
+    auth=OAuthToken("sk-ant-oat-...replace-me..."),  # the exact Claude subscription token YOUR
+                                                     #   app manages (redacted repr) — not the user's
 )
 
 print(mac.snapshot("Finder").splitlines()[0])   # deterministic primitives work as usual
 print(mac.list_credentials())                    # this app's OWN (empty) credential store
 mac.notify("Demo App is wired up.")
 
-# The agent loop would need an injected credential because auth="none":
-#   mac = Hunch(..., auth=OAuthToken(token_your_app_stores))
+# With the injected token above, the agent loop runs on YOUR credential:
 #   mac.agent.run("file the invoices in ~/Downloads")
+# (Codex apps authenticate via `codex login`; no token to inject.)
 mac.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hunch-sdk"
-version = "0.5.5"
+version = "0.6.0"
 description = "Drive your Mac focus-free over MCP: OS APIs, AppleScript, CDP, and Accessibility."
 readme = "README.md"
 license = "Apache-2.0"
@@ -31,9 +31,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-api = ["anthropic>=0.80"]                    # agent loop on a metered ANTHROPIC_API_KEY
-subscription = ["claude-agent-sdk>=0.2"]     # agent loop on your Claude subscription (hunch login)
-agent = ["anthropic>=0.80", "claude-agent-sdk>=0.2"]   # both backends
+subscription = ["claude-agent-sdk>=0.2"]     # the 'claude' provider (Claude sign-in)
+codex = ["openai-codex>=0.144"]              # the 'codex' provider (OpenAI Codex; SDK is beta)
+agent = ["claude-agent-sdk>=0.2", "openai-codex>=0.144"]   # both providers
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/hunch"]

--- a/src/hunch/__init__.py
+++ b/src/hunch/__init__.py
@@ -5,11 +5,11 @@ doctor) must work even when pyobjc or the MCP SDK are missing, so nothing here
 may import them. The server loads lazily via `hunch serve`.
 """
 
-__version__ = "0.5.5"
+__version__ = "0.6.0"
 
 # Public SDK surface, loaded lazily (PEP 562) so bare `import hunch` stays dependency-free.
-# Names mapped to .sdk/.agent/.local_mac pull in pyobjc; .errors and .auth stay stdlib-only,
-# so hunch.login()/logout()/auth_status and the exceptions work even without the heavy deps.
+# Names mapped to .sdk/.agent/.local_mac pull in pyobjc; .errors/.auth/.providers stay
+# stdlib-only, so hunch.provider(...)/AuthStatus and the exceptions work without the heavy deps.
 _LAZY = {
     "Hunch": ".sdk",
     "Agent": ".agent",
@@ -19,11 +19,10 @@ _LAZY = {
     "AccessibilityNotGranted": ".errors",
     "WebNotOpen": ".errors",
     "StaleRef": ".local_mac",
-    "login": ".auth",         # sign in for the agent loop's subscription backend
-    "logout": ".auth",
-    "AuthStatus": ".auth",
-    "ApiKey": ".auth",        # injected agent-loop credentials (developer-first)
-    "OAuthToken": ".auth",
+    "provider": ".providers",   # hunch.provider("claude"|"codex") — auth + agent loop, standalone
+    "Provider": ".providers",
+    "AuthStatus": ".providers",  # the uniform sign-in status returned by provider.status()
+    "OAuthToken": ".auth",      # the Claude subscription token, for Hunch(provider="claude", auth=...)
     "ConsentRequest": ".errors",   # what a custom confirm callback receives
 }
 

--- a/src/hunch/agent.py
+++ b/src/hunch/agent.py
@@ -27,8 +27,9 @@ from dataclasses import dataclass, field
 
 from .playbook import HUNCH_PLAYBOOK
 from .gate import HunchError, ApprovalDenied, AccessibilityNotGranted, WebNotOpen
+from .backends.base import Backend   # dependency-free ABC; no import cycle (see backends/__init__)
 
-__all__ = ["Agent", "AgentResult"]
+__all__ = ["Agent", "AgentResult", "ApiBackend", "SubscriptionBackend"]
 
 DEFAULT_MODEL = "claude-opus-4-8"
 
@@ -411,13 +412,18 @@ def _sdk_tools(mac):
             for t in AGENT_TOOLS]
 
 
-class _SubscriptionRunner:
+class SubscriptionBackend(Backend):
     """The subscription backend: claude-agent-sdk on the user's Claude sign-in
     (hunch.login() / Claude Code / CLAUDE_CODE_OAUTH_TOKEN — see hunch.auth).
 
     Sync facade over the SDK's asyncio client: a daemon event-loop thread plus
     run_coroutine_threadsafe, so Agent.run() stays synchronous. The connected client
     is kept across run() calls (continuation) while the options are unchanged."""
+
+    name = "subscription"
+    provider = "anthropic"
+    extra = "subscription"
+    default_model = None   # let the subscription CLI pick its own default model
 
     def __init__(self, hunch, auth=None, app_id=None, can_use_tool=None):
         self._h = hunch
@@ -428,6 +434,19 @@ class _SubscriptionRunner:
         self._thread = None
         self._client = None
         self._opts_key = None
+
+    @classmethod
+    def deps_installed(cls):
+        try:
+            import claude_agent_sdk  # noqa: F401
+            return True
+        except ImportError:
+            return False
+
+    @classmethod
+    def available(cls, app_id=None):
+        from . import auth as auth_mod
+        return cls.deps_installed() and auth_mod.subscription_available(app_id)
 
     # — event-loop plumbing —
     def _call(self, coro):
@@ -517,7 +536,8 @@ class _SubscriptionRunner:
         return AgentResult(text=final_text, turns=turns, stop_reason=stop_reason,
                            usage=usage, aborted=aborted)
 
-    def run(self, task, model=None, max_turns=40, on_event=None, system_suffix="", effort=None):
+    def run(self, task, model=None, max_turns=40, on_event=None, system_suffix="",
+            effort=None, max_tokens=None):   # max_tokens ignored: the CLI manages output limits
         try:
             import claude_agent_sdk as sdk
         except ImportError as e:
@@ -574,98 +594,42 @@ class AgentResult:
     aborted: bool = False
 
 
-class Agent:
-    """The agent loop. Created lazily as `Hunch.agent`. Holds conversation state across
-    run() calls (continuation); call reset() to start a fresh task."""
+# Back-compat + registry alias: the subscription backend used to be named _SubscriptionRunner.
+# Tests and older callers import hunch.agent._SubscriptionRunner; keep it pointing at the class.
+_SubscriptionRunner = SubscriptionBackend
 
-    def __init__(self, hunch, client=None, backend="auto", auth=None, can_use_tool=None):
-        from .auth import ApiKey, OAuthToken
+
+class ApiBackend(Backend):
+    """The 'api' backend: our own tool loop on the `anthropic` SDK, metered on an
+    ANTHROPIC_API_KEY (env, or an injected hunch.ApiKey). Tools run IN-PROCESS against
+    the caller's live Hunch instance via _dispatch_core, so refs, gates, and simultaneous
+    mode are exactly the caller's. Conversation state (messages) lives here so run() can
+    continue a task across calls; reset() clears it."""
+
+    name = "api"
+    provider = "anthropic"
+    extra = "api"
+    default_model = DEFAULT_MODEL
+
+    def __init__(self, hunch, *, client=None, auth=None, app_id=None):
         self._h = hunch
         self._client = client          # test seam; None -> lazily anthropic.Anthropic()
-        self.backend = backend         # "auto" | "api" | "subscription" (per-run override too)
-        self.auth = auth               # None (ambient) | ApiKey | OAuthToken | "none"
-        # Optional host-owned permission callback. When set, the subscription backend hands EVERY
-        # tool to it — a raw claude-agent-sdk can_use_tool(tool_name, input, context) ->
-        # PermissionResultAllow/Deny — instead of auto-allowing Hunch tools. This is how the Hunch
-        # app routes each tool through its own Approve/Deny UI. (Subscription backend only.)
-        self._can_use_tool = can_use_tool
+        self._auth = auth              # ApiKey (injected) or None (ambient)
+        self._app_id = app_id
         self.messages = []
-        self._abort = False            # api backend: between-turns cancel flag (see interrupt())
-        self._sub = None               # _SubscriptionRunner, built on first subscription run
-        if not (auth is None or auth == "none" or isinstance(auth, (ApiKey, OAuthToken))):
-            raise HunchError(f"unknown auth {auth!r} — pass hunch.ApiKey(...), "
-                             "hunch.OAuthToken(...), 'none', or None (ambient)")
-        implied = self._implied_backend()
-        if implied and backend not in ("auto", implied):
-            raise HunchError(f"auth={type(auth).__name__}(...) implies the {implied!r} backend, "
-                             f"but backend={backend!r} was requested")
+        self._abort = False            # between-turns cancel flag (see interrupt())
 
-    @property
-    def _app_id(self):
-        return getattr(self._h, "_app_id", None)   # set by Hunch when namespaced
-
-    def _implied_backend(self):
-        from .auth import ApiKey, OAuthToken
-        if isinstance(self.auth, ApiKey):
-            return "api"
-        if isinstance(self.auth, OAuthToken):
-            return "subscription"
-        return None
-
-    def _resolve_backend(self, backend):
-        """Injected credentials imply their backend; an explicit choice wins otherwise;
-        "auto" picks by ambient credentials — the SAME order hunch.auth.status() reports.
-        auth="none" means never scavenge: with no injected credential, raise."""
-        implied = self._implied_backend()
-        b = backend or implied or self.backend or "auto"
-        if implied and b != implied:
-            raise HunchError(f"auth={type(self.auth).__name__}(...) implies the {implied!r} "
-                             f"backend, but backend={b!r} was requested")
-        if self.auth == "none" and implied is None:
-            raise HunchError("auth='none' — ambient credentials are disabled for this instance; "
-                             "pass hunch.ApiKey(...) or hunch.OAuthToken(...) (or auth=None "
-                             "to allow ambient resolution)")
-        if b in ("api", "subscription"):
-            return b
-        if b != "auto":
-            raise HunchError(f"unknown backend {b!r} — use 'api', 'subscription', or 'auto'")
-        if self._client is not None:       # injected client (test seam) is an api client
-            return "api"
-        if os.environ.get("ANTHROPIC_API_KEY"):
-            return "api"
-        from . import auth
+    @classmethod
+    def deps_installed(cls):
         try:
-            import claude_agent_sdk  # noqa: F401
-            have_sdk = True
+            import anthropic  # noqa: F401
+            return True
         except ImportError:
-            have_sdk = False
-        if have_sdk and auth.subscription_available(self._app_id):
-            return "subscription"
-        raise HunchError(
-            "no credentials for the agent loop — call hunch.login() to use your Claude "
-            "subscription, or set ANTHROPIC_API_KEY for the metered API"
-            + ("" if have_sdk else " (subscription backend also needs: "
-                                   "pip install 'hunch-sdk[agent]')"))
+            return False
 
-    def reset(self):
-        """Clear the conversation for an unrelated task (same Hunch instance and gates)."""
-        self.messages = []
-        if self._sub is not None:
-            self._sub.reset()
-
-    def close(self):
-        """Stop the subscription backend's event-loop thread (no-op otherwise)."""
-        if self._sub is not None:
-            self._sub.close()
-            self._sub = None
-
-    def interrupt(self):
-        """Stop an in-flight run() while KEEPING the conversation (the next run() continues it).
-        Call from another thread (e.g. a Stop button). Subscription backend: interrupts the current
-        turn immediately; api backend: cancels before the next turn. No-op if nothing is running."""
-        self._abort = True                        # api backend: checked between turns
-        if self._sub is not None:
-            self._sub.interrupt()                 # subscription backend: immediate
+    @classmethod
+    def available(cls, app_id=None):
+        return cls.deps_installed() and bool(os.environ.get("ANTHROPIC_API_KEY"))
 
     def _ensure_client(self):
         if self._client is None:
@@ -675,8 +639,8 @@ class Agent:
             except ImportError as e:
                 raise HunchError("the agent loop needs the optional 'anthropic' package — "
                                  "install it with: pip install 'hunch-sdk[agent]'") from e
-            if isinstance(self.auth, ApiKey):      # injected key, nothing ambient
-                self._client = anthropic.Anthropic(api_key=self.auth.value)
+            if isinstance(self._auth, ApiKey):     # injected key, nothing ambient
+                self._client = anthropic.Anthropic(api_key=self._auth.value)
             else:
                 self._client = anthropic.Anthropic()   # env key / auth token / ant profile
         return self._client
@@ -704,25 +668,14 @@ class Agent:
                   "cache_creation_input_tokens", "cache_read_input_tokens"):
             usage[k] = usage.get(k, 0) + (getattr(resp_usage, k, 0) or 0)
 
+    def interrupt(self):
+        self._abort = True             # checked between turns
+
+    def reset(self):
+        self.messages = []
+
     def run(self, task, model=None, max_turns=40, on_event=None,
-            system_suffix="", effort=None, max_tokens=16000, backend=None):
-        """Run the agent loop until Claude finishes the task (end_turn), is blocked, or hits
-        max_turns. Returns an AgentResult. on_event(kind, data) receives 'text' | 'tool' |
-        'tool_result' | 'done' | 'error' as work streams.
-
-        backend: 'api' | 'subscription' | None (-> the Agent's default, normally 'auto').
-        model=None -> claude-opus-4-8 on the api backend, the subscription's own default
-        on the subscription backend. max_tokens applies to the api backend only (the
-        subscription CLI manages its own output limits)."""
-        if self._resolve_backend(backend) == "subscription":
-            if self._sub is None:
-                from .auth import OAuthToken
-                self._sub = _SubscriptionRunner(
-                    self._h, auth=self.auth if isinstance(self.auth, OAuthToken) else None,
-                    app_id=self._app_id, can_use_tool=self._can_use_tool)
-            return self._sub.run(task, model=model, max_turns=max_turns, on_event=on_event,
-                                 system_suffix=system_suffix, effort=effort)
-
+            system_suffix="", effort=None, max_tokens=16000):
         model = model or DEFAULT_MODEL
         client = self._ensure_client()   # friendly HunchError if 'anthropic' isn't installed
         try:
@@ -737,7 +690,7 @@ class Agent:
         self._abort = False
 
         for turn in range(1, max_turns + 1):
-            if self._abort:                       # interrupt() between turns (api backend)
+            if self._abort:                       # interrupt() between turns
                 stop_reason, aborted = "interrupted", True
                 emit("error", "interrupted")
                 break
@@ -779,4 +732,71 @@ class Agent:
             emit("error", f"aborted after max_turns={max_turns}")
 
         return AgentResult(text=final_text, turns=turn, stop_reason=stop_reason,
-                         usage=usage, aborted=aborted)
+                           usage=usage, aborted=aborted)
+
+
+class Agent:
+    """The agent loop, created lazily as `Hunch.agent`. Runs the loop on the Hunch instance's
+    configured PROVIDER (hunch.provider.Provider): it builds that provider's Backend on first
+    use and delegates run/interrupt/reset/close to it, holding it across run() calls so a task
+    continues; reset() starts fresh. The provider — not the Agent — decides the transport, so
+    there is no backend selection here."""
+
+    def __init__(self, hunch, provider=None, auth=None, can_use_tool=None):
+        self._h = hunch
+        self._provider = provider      # a hunch.provider.Provider (claude / codex)
+        self.auth = auth               # provider-appropriate injected credential, or None
+        # Optional host-owned permission callback handed to backends that support it (the
+        # Hunch app routes each tool through its own Approve/Deny UI via this).
+        self._can_use_tool = can_use_tool
+        self._backend = None           # the provider's Backend, built on first run
+
+    @property
+    def _app_id(self):
+        return getattr(self._h, "_app_id", None)   # set by Hunch when namespaced
+
+    @property
+    def provider(self):
+        """The configured provider's name ('claude' | 'codex'), or None."""
+        return getattr(self._provider, "name", None)
+
+    @property
+    def messages(self):
+        """The backend's conversation, when it keeps one here (empty for delegated backends
+        that hold their transcript inside their own SDK session)."""
+        return getattr(self._backend, "messages", [])
+
+    def _backend_(self):
+        if self._backend is None:
+            if self._provider is None:
+                raise HunchError("no provider set for the agent loop — construct "
+                                 "Hunch(provider='claude') or Hunch(provider='codex')")
+            self._backend = self._provider.make_backend(
+                self._h, auth=self.auth, app_id=self._app_id, can_use_tool=self._can_use_tool)
+        return self._backend
+
+    def reset(self):
+        """Clear the conversation for an unrelated task (same Hunch instance and gates)."""
+        if self._backend is not None:
+            self._backend.reset()
+
+    def close(self):
+        """Release the backend's resources (event-loop threads, sessions)."""
+        if self._backend is not None:
+            self._backend.close()
+            self._backend = None
+
+    def interrupt(self):
+        """Stop an in-flight run() while KEEPING the conversation (the next run() continues it).
+        Call from another thread (e.g. a Stop button). No-op if nothing is running."""
+        if self._backend is not None:
+            self._backend.interrupt()
+
+    def run(self, task, model=None, max_turns=40, on_event=None,
+            system_suffix="", effort=None, max_tokens=16000):
+        """Run the agent loop until the model finishes the task (end_turn), is blocked, or hits
+        max_turns. Returns an AgentResult. on_event(kind, data) receives 'text' | 'tool' |
+        'tool_result' | 'done' | 'error' as work streams. model=None uses the provider's own
+        default model."""
+        return self._backend_().run(task, model=model, max_turns=max_turns, on_event=on_event,
+                                    system_suffix=system_suffix, effort=effort, max_tokens=max_tokens)

--- a/src/hunch/auth.py
+++ b/src/hunch/auth.py
@@ -252,3 +252,78 @@ def logout(app_id=None):
     elif source in ("api_key", "env_token"):
         msgs.append(f"note: {desc} is still set in this shell.")
     return msgs
+
+
+# ── OpenAI Codex auth (the 'codex' backend) ─────────────────────────────────────
+# MANUAL authentication only — no ambient credential detection (the same stance the app
+# took for Claude, which stopped scavenging a detected login because it expired mid-task).
+# Authorize explicitly through the SDK with codex_login(); the codex backend then relies on
+# the SDK's stored session, or on an injected hunch.OpenAIKey(...).
+
+def _codex_client():
+    """A Codex SDK client for auth operations, or a HunchError if openai-codex is missing."""
+    try:
+        import openai_codex
+    except ImportError as e:
+        raise HunchError("Codex auth needs the optional 'openai-codex' package (beta) — "
+                         "install it with: pip install --pre openai-codex "
+                         "(or: pip install 'hunch-sdk[codex]')") from e
+    return openai_codex.Codex()
+
+
+@dataclass
+class CodexAuthStatus:
+    """The 'codex' backend's sign-in state, as data (parallels AuthStatus for Claude).
+    method is 'chatgpt' | 'api_key' | None."""
+    logged_in: bool
+    method: str | None = None
+    email: str | None = None
+    plan: str | None = None
+
+
+def codex_login():
+    """Authorize the 'codex' backend from Python — an interactive ChatGPT/Codex browser
+    sign-in that BLOCKS until you finish (needs a local browser). For a remote/headless
+    machine use codex_device_login(). Returns the resulting CodexAuthStatus; raises
+    HunchError if openai-codex is missing. (Subscription/login only — no API-key path.)"""
+    handle = _codex_client().login_chatgpt()   # its auth_url opens a browser
+    handle.wait()                              # block until the browser flow completes
+    return codex_status()
+
+
+def codex_device_login():
+    """Headless/remote ChatGPT sign-in for the 'codex' backend. Returns the SDK's
+    device-code handle exposing .verification_url, .user_code, and .wait(): show the code
+    and URL to the user, then call handle.wait() to block until they finish."""
+    return _codex_client().login_chatgpt_device_code()
+
+
+def codex_logout():
+    """Sign the 'codex' backend out (clears the SDK's stored Codex session)."""
+    _codex_client().logout()
+    return True
+
+
+def codex_status():
+    """Who, if anyone, is signed in for the 'codex' backend — an EXPLICIT check (asks the
+    SDK's account()), never ambient scavenging. Returns a CodexAuthStatus; logged_in is
+    False when openai-codex is missing or no session exists."""
+    try:
+        codex = _codex_client()
+    except HunchError:
+        return CodexAuthStatus(False)
+    try:
+        resp = codex.account()
+    except Exception:
+        return CodexAuthStatus(False)
+    # NB: `requires_openai_auth` is NOT a logged-out signal (it's True even for a signed-in
+    # ChatGPT account). Being logged in = a populated account.root (ChatgptAccount/ApiKeyAccount).
+    acct = getattr(getattr(resp, "account", None), "root", None)
+    kind = type(acct).__name__ if acct is not None else ""
+    if kind == "ChatgptAccount":
+        plan = getattr(acct, "plan_type", None)
+        plan = getattr(plan, "value", plan)          # PlanType enum -> its str value
+        return CodexAuthStatus(True, "chatgpt", getattr(acct, "email", None), plan)
+    if kind == "ApiKeyAccount":
+        return CodexAuthStatus(True, "api_key")
+    return CodexAuthStatus(False)

--- a/src/hunch/backends/__init__.py
+++ b/src/hunch/backends/__init__.py
@@ -1,0 +1,52 @@
+"""backends — the provider registry for the agent loop.
+
+The single source of truth for "what backends exist". Agent, sdk.Hunch's
+constructor validation, and `hunch doctor` all read this, so adding a provider is
+one entry here (plus its Backend subclass) — not edits scattered across the SDK.
+
+Imports are lazy (inside the functions) so that `import hunch.backends` — and
+`from .backends.base import Backend`, which agent.py does at import time — never
+pulls in the agent module or the optional LLM SDKs. `hunch.backends.base` stays
+dependency-free; the concrete backends load only when actually resolved.
+"""
+from .base import Backend
+
+__all__ = ["Backend", "NAMES", "get", "available", "meta", "provider_names"]
+
+# Ordered: 'auto' resolution prefers earlier entries when several are usable.
+NAMES = ("api", "subscription", "codex")
+
+
+def get(name):
+    """The Backend subclass for a registered name, or raise HunchError for an
+    unknown name (listing the valid ones)."""
+    if name == "api":
+        from ..agent import ApiBackend
+        return ApiBackend
+    if name == "subscription":
+        from ..agent import SubscriptionBackend
+        return SubscriptionBackend
+    if name == "codex":
+        from .codex import CodexBackend
+        return CodexBackend
+    from ..errors import HunchError
+    raise HunchError(f"unknown backend {name!r} — use "
+                     + ", ".join(repr(n) for n in NAMES) + ", or 'auto'")
+
+
+def available(name, app_id=None):
+    """True when the named backend could run right now (deps installed AND a
+    credential resolvable)."""
+    return get(name).available(app_id)
+
+
+def meta(name):
+    """(provider, extra, default_model) for a registered backend — cheap, no
+    credential probing."""
+    cls = get(name)
+    return cls.provider, cls.extra, cls.default_model
+
+
+def provider_names():
+    """Map of backend name -> user-facing provider ('anthropic' | 'openai')."""
+    return {n: get(n).provider for n in NAMES}

--- a/src/hunch/backends/base.py
+++ b/src/hunch/backends/base.py
@@ -1,0 +1,90 @@
+"""backends/base.py — the provider abstraction for the Hunch agent loop.
+
+Every LLM transport the agent can drive this Mac with is a `Backend`: the metered
+Anthropic API (`api`), the user's Claude subscription via claude-agent-sdk
+(`subscription`), and OpenAI's Codex via the Codex SDK (`codex`). They are peers —
+`Agent` is a thin facade that resolves a name to a Backend and delegates to it.
+
+A Backend takes the SAME building blocks every provider shares (defined in
+hunch.agent): the AGENT_TOOLS schema, the HUNCH_PLAYBOOK system prompt, the
+_dispatch_core tool executor, the AgentResult shape, and the on_event(kind, data)
+stream — kind is one of 'text' | 'tool' | 'tool_result' | 'done' | 'error'. A new
+provider only has to implement `run()` (its own loop) against those; everything
+else (tools, gates, refs, streaming contract) comes for free.
+
+To ADD a provider: subclass Backend, set the class metadata, implement run(), and
+register the class in hunch.backends (the REGISTRY). Nothing else in the SDK needs
+to learn the new name — Agent, sdk.Hunch validation, and `hunch doctor` all read
+the registry.
+"""
+from abc import ABC, abstractmethod
+
+from ..errors import HunchError
+
+__all__ = ["Backend"]
+
+
+class Backend(ABC):
+    """One LLM transport for the agent loop. Subclasses fill in the class metadata
+    and run(); the default interrupt/reset/close are no-ops so a stateless backend
+    needn't implement them.
+
+    Class metadata (read by the registry, sdk validation, and `hunch doctor`):
+      name          the backend id used in Hunch(agent_backend=...) / run(backend=...)
+      provider      the model provider ('anthropic' | 'openai') — the user-facing choice
+      extra         the pip extra that installs its optional deps ('hunch-sdk[<extra>]')
+      default_model model used when run(model=None), or None to let the transport pick
+    """
+
+    name: str = ""
+    provider: str = ""
+    extra: str = ""
+    default_model = None
+
+    def __init__(self, hunch, *, auth=None, app_id=None, can_use_tool=None):
+        self._h = hunch
+        self._auth = auth              # an injected credential for this provider, or None
+        self._app_id = app_id          # namespaces per-app credential storage
+        self._permit = can_use_tool    # host-owned permission callback (backends that support it)
+
+    # ── the one thing every provider must implement ─────────────────────────────
+    @abstractmethod
+    def run(self, task, *, model=None, max_turns=40, on_event=None,
+            system_suffix="", effort=None, max_tokens=16000):
+        """Drive the task to completion and return an AgentResult. Stream progress by
+        calling on_event(kind, data). Backends ignore kwargs that don't apply to them
+        (e.g. the subscription/codex transports manage their own output limits, so they
+        ignore max_tokens)."""
+        raise NotImplementedError
+
+    # ── lifecycle: overridden by stateful backends (default no-ops) ──────────────
+    def interrupt(self):
+        """Stop an in-flight run() while keeping the conversation (the next run()
+        continues it). Called from another thread (e.g. a Stop button)."""
+
+    def reset(self):
+        """Drop the conversation so the next run() starts a fresh task."""
+
+    def close(self):
+        """Release any resources (event-loop threads, subprocesses, sessions)."""
+
+    # ── availability (deps installed AND a usable credential) ────────────────────
+    @classmethod
+    def available(cls, app_id=None):
+        """True when this backend could run right now — its optional dependency is
+        importable AND a credential is resolvable. Used by 'auto' resolution and
+        `hunch doctor`. Subclasses override with a real probe."""
+        return False
+
+    @classmethod
+    def deps_installed(cls):
+        """True when the optional dependency package is importable (independent of
+        credentials). Subclasses override."""
+        return False
+
+    # small shared helper so subclasses raise a consistent missing-dep error
+    @classmethod
+    def _missing_dep_error(cls, pkg):
+        return HunchError(
+            f"the {cls.name!r} backend needs the optional {pkg!r} package — "
+            f"install it with: pip install 'hunch-sdk[{cls.extra}]'")

--- a/src/hunch/backends/codex.py
+++ b/src/hunch/backends/codex.py
@@ -1,0 +1,246 @@
+"""backends/codex.py — the 'codex' backend: OpenAI's Codex agent drives this Mac.
+
+For people who live in Codex rather than Claude Code. Unlike the api/subscription
+backends (Anthropic), this hands the whole agent loop to OpenAI's Codex SDK and
+exposes Hunch's tools to it as an MCP server — Codex is an MCP *client*, so the
+SAME tools the other backends use are the ones Codex drives, via the hunch MCP
+server (`hunch serve`).
+
+Two architectural facts follow from Codex spawning its CLI runtime as a subprocess
+(it cannot host an in-process MCP server the way claude-agent-sdk can):
+
+  • Tools execute in a SEPARATE `hunch serve` process, not the caller's live Hunch
+    instance. Refs stay self-consistent within a session and the tool set/gates are
+    identical, but caller-side live state (a simultaneous_mode toggle on THIS object)
+    doesn't reach that process.
+  • Host-owned permission routing (Agent(can_use_tool=...) / the app's Approve-Deny
+    popover) does NOT govern Codex's tool calls. The dangerous verbs are gated by the
+    hunch server's own click-to-approve dialogs instead. (Routing Codex's approval
+    protocol into the host callback is a future enhancement.)
+
+Auth is a `codex login` (ChatGPT/Codex subscription) session — set it up with
+hunch.provider("codex").login() or `codex login`. No API-key path is exposed.
+
+The Codex Python SDK (`openai-codex`, beta) is an optional dependency, imported
+lazily. The SDK touch-points are `_open_thread()` and `_run_turn()`; everything else
+(config, playbook, result translation) is plain Python and unit-tested with fakes.
+"""
+import json
+import os
+import sys
+
+from .base import Backend
+from ..errors import HunchError
+
+__all__ = ["CodexBackend"]
+
+# Codex's per-thread instruction channel is additive over its base system prompt, so we
+# frame the (coding-oriented) agent as a Mac driver, then hand it the Hunch playbook.
+_PREAMBLE = (
+    "# Hunch — you are controlling this Mac\n\n"
+    "You are NOT doing a software-engineering task. You are driving the user's real "
+    "macOS machine on their behalf through the `hunch` MCP tools. Prefer the hunch "
+    "tools over your shell/file-editing tools for anything involving apps, files, the "
+    "web, or the screen. Follow this playbook exactly.\n\n")
+
+
+class CodexBackend(Backend):
+    """OpenAI Codex as the agent loop, with Hunch's tools attached over MCP."""
+
+    name = "codex"
+    provider = "openai"
+    extra = "codex"
+    default_model = None   # let Codex pick its own default
+
+    def __init__(self, hunch, *, auth=None, app_id=None, can_use_tool=None):
+        super().__init__(hunch, auth=auth, app_id=app_id, can_use_tool=can_use_tool)
+        self._thread = None            # the live Codex thread (continuation across run())
+        self._codex = None             # the Codex client
+
+    # ── availability ────────────────────────────────────────────────────────────
+    @classmethod
+    def deps_installed(cls):
+        try:
+            import openai_codex  # noqa: F401
+            return True
+        except ImportError:
+            return False
+
+    @classmethod
+    def available(cls, app_id=None):
+        # NO ambient credential detection (matches the app's explicit-auth pattern for
+        # Claude, which stopped scavenging a detected login because it expired mid-task).
+        # A backend is "available" when its SDK is installed; whether a valid Codex login
+        # exists is decided by the SDK at run time. Authenticate via hunch.provider("codex")
+        # .login() / `codex login`.
+        return cls.deps_installed()
+
+    @staticmethod
+    def _codex_home():
+        return os.path.expanduser(os.environ.get("CODEX_HOME", "~/.codex"))
+
+    # ── tool exposure: the hunch MCP server Codex connects to ────────────────────
+    def _mcp_server_command(self):
+        """(command, args, env) that launches the hunch MCP server for Codex to consume.
+        We run it via the current interpreter (`python -m hunch serve`) so it works
+        without relying on the `hunch` script being on the subprocess PATH."""
+        env = {
+            "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+            "HOME": os.path.expanduser("~"),
+        }
+        # deliberately DO NOT set HUNCH_NO_INTERNAL_GATE — we want the server to run its
+        # own click-to-approve dialogs, since host permission routing can't reach it here.
+        return sys.executable, ["-m", "hunch", "serve"], env
+
+    def _config_overrides(self):
+        """Codex `-c key=value` config overrides registering the hunch MCP server, as the
+        tuple of TOML-encoded strings CodexConfig(config_overrides=...) expects (nothing on
+        disk is edited). json.dumps yields valid TOML for these scalars/arrays."""
+        cmd, args, env = self._mcp_server_command()
+        ov = [f"mcp_servers.hunch.command={json.dumps(cmd)}",
+              f"mcp_servers.hunch.args={json.dumps(args)}"]
+        for k, v in env.items():
+            ov.append(f"mcp_servers.hunch.env.{k}={json.dumps(v)}")
+        return tuple(ov)
+
+    # ── the playbook, delivered as Codex developer instructions ──────────────────
+    def _instructions(self):
+        from ..playbook import HUNCH_PLAYBOOK
+        from ..agent import AGENT_ADDENDUM
+        return _PREAMBLE + HUNCH_PLAYBOOK + "\n" + AGENT_ADDENDUM
+
+    def _working_dir(self):
+        """A private cwd for the Codex thread, so it never touches the user's project dir."""
+        d = os.path.join(self._codex_home(), "hunch-workdir")
+        os.makedirs(d, exist_ok=True)
+        return d
+
+    # ── result translation: TurnResult.items -> Hunch's on_event contract ────────
+    @staticmethod
+    def _result_text(result):
+        """Pull readable text out of a Codex McpToolCallResult (its .content is a list of
+        {type,text} blocks, mirroring MCP tool output); fall back to str()."""
+        content = getattr(result, "content", None)
+        if isinstance(content, list):
+            parts = [c.get("text", "") if isinstance(c, dict) else getattr(c, "text", "")
+                     for c in content]
+            joined = " ".join(p for p in parts if p).strip()
+            if joined:
+                return joined
+        return str(result)
+
+    @classmethod
+    def _emit_item(cls, item, emit):
+        """Map one ThreadItem (a pydantic RootModel; real variant at .root) onto
+        emit(kind, data). Returns the item's agent text if it is a message, else ''."""
+        root = getattr(item, "root", item)
+        itype = getattr(root, "type", "") or ""
+        if itype == "mcpToolCall":
+            emit("tool", {"name": getattr(root, "tool", ""),
+                          "input": getattr(root, "arguments", None)})
+            result = getattr(root, "result", None)
+            if result is not None:
+                emit("tool_result", cls._result_text(result)[:200])
+            return ""
+        if itype == "commandExecution":               # Codex ran its own shell (not a hunch tool)
+            emit("tool", {"name": "shell", "input": getattr(root, "command", "")})
+            return ""
+        if itype == "agentMessage":
+            text = (getattr(root, "text", "") or "").strip()
+            if text:
+                emit("text", text)
+            return text
+        return ""
+
+    @staticmethod
+    def _usage_dict(result):
+        u = getattr(result, "usage", None)
+        if u is None:
+            return {}
+        dump = getattr(u, "model_dump", None)
+        try:
+            return dump() if dump else (u if isinstance(u, dict) else {})
+        except Exception:
+            return {}
+
+    # ── SDK touch-points (isolated so they can be faked in tests) ────────────────
+    def _open_thread(self, model, cwd):
+        """Create/continue a Codex thread with the hunch MCP server attached and the
+        playbook as developer instructions. The one place the SDK's client surface is
+        used; override in tests."""
+        import openai_codex as oc
+        if self._codex is None:
+            # Relies on the user's `codex login` session (no API-key path).
+            self._codex = oc.Codex(config=oc.CodexConfig(config_overrides=self._config_overrides()))
+        if self._thread is None:
+            kwargs = dict(cwd=cwd, developer_instructions=self._instructions(),
+                          sandbox=oc.Sandbox.workspace_write)
+            if model:
+                kwargs["model"] = model
+            self._thread = self._codex.thread_start(**kwargs)
+        return self._thread
+
+    def _run_turn(self, thread, task):
+        """Run one turn to completion and return the SDK's TurnResult. Isolated so tests
+        fake it; the beta SDK's blocking run(input) returns items + final_response."""
+        return thread.run(task)
+
+    # ── run ──────────────────────────────────────────────────────────────────────
+    def run(self, task, model=None, max_turns=40, on_event=None,
+            system_suffix="", effort=None, max_tokens=None):
+        if not self.deps_installed():
+            raise HunchError(
+                "the 'codex' backend needs the optional 'openai-codex' package (beta) — "
+                "install it with: pip install --pre openai-codex  "
+                "(or: pip install 'hunch-sdk[codex]')")
+        # No credential pre-check: we rely on manual authentication — the SDK's own session
+        # from a `hunch.provider("codex").login()` / `codex login`. If nothing is authorized,
+        # the SDK raises and we translate it into a login hint below.
+        emit = on_event or (lambda kind, data: None)
+        model = model or self.default_model
+        cwd = self._working_dir()
+
+        try:
+            thread = self._open_thread(model, cwd)
+            result = self._run_turn(thread, task)
+        except Exception as e:  # noqa: BLE001 — surface transport/SDK failures as an error result
+            msg = f"codex run failed: {e}"
+            if any(w in str(e).lower() for w in ("login", "auth", "unauthor", "credential", "401")):
+                msg += " — authenticate first: hunch.provider('codex').login() (or `codex login`)"
+            emit("error", msg)
+            return _result("", "error", True, {}, 0)
+
+        final = ""
+        items = getattr(result, "items", None) or []
+        for item in items:
+            text = self._emit_item(item, emit)
+            if text:
+                final = text
+        final = final or (getattr(result, "final_response", "") or "")
+        err = getattr(result, "error", None)
+        aborted = err is not None
+        usage = self._usage_dict(result)
+        if aborted:
+            emit("error", str(err))
+        else:
+            emit("done", final)
+        return _result(final, "error" if aborted else "end_turn", aborted, usage, len(items))
+
+    def reset(self):
+        self._thread = None            # drop the conversation; next run() starts a fresh thread
+
+    def close(self):
+        self._thread = None
+        codex, self._codex = self._codex, None
+        if codex is not None:
+            closer = getattr(codex, "close", None)
+            if closer:
+                try:
+                    closer()
+                except Exception:
+                    pass
+
+
+def _result(text, stop_reason, aborted, usage, turns):
+    from ..agent import AgentResult
+    return AgentResult(text=text, turns=turns, stop_reason=stop_reason, usage=usage, aborted=aborted)

--- a/src/hunch/cli.py
+++ b/src/hunch/cli.py
@@ -313,32 +313,25 @@ def cmd_doctor(args):
     except OSError:
         _ok(f"CDP port {CDP_PORT} free")
 
-    print("\nAgent auth (only needed for the agent loop — mac.agent.run)")
+    print("\nAgent providers (only needed for the agent loop — mac.agent.run)")
     try:
-        from . import auth
-        source, desc = auth.resolve()
-        if source:
-            _ok(f"credentials found: {desc}")
+        from . import providers as _pv, auth
+        if _pv.PROVIDERS["claude"].deps_installed():
+            st = auth.status()
+            if st.subscription_ready:
+                _ok(f"claude: installed, signed in{f' ({st.email})' if st.email else ''}")
+            else:
+                _warn("claude: installed, not signed in — "
+                      "mac.login() / hunch.provider('claude').login()")
         else:
-            _warn("no agent credentials — from Python, hunch.login() (Claude subscription) or "
-                  "set ANTHROPIC_API_KEY (metered API). The MCP server and instance SDK don't need this")
-        have_api = True
-        have_sub = True
-        try:
-            import anthropic  # noqa: F401
-        except ImportError:
-            have_api = False
-        try:
-            import claude_agent_sdk  # noqa: F401
-        except ImportError:
-            have_sub = False
-        if have_api or have_sub:
-            backends = [b for b, ok_ in (("api", have_api), ("subscription", have_sub)) if ok_]
-            _ok(f"agent backends installed: {', '.join(backends)}")
+            _warn("claude: agent backend not installed — pip install 'hunch-sdk[subscription]'")
+        if _pv.PROVIDERS["codex"].deps_installed():
+            _ok("codex: installed — sign in with mac.login() / "
+                "hunch.provider('codex').login() (or `codex login`)")
         else:
-            _warn("no agent backend installed — pip install 'hunch-sdk[agent]' to use mac.agent.run")
+            _warn("codex: agent backend not installed — pip install 'hunch-sdk[codex]'")
     except Exception as e:
-        failed |= _fail(f"auth check errored: {e}")
+        failed |= _fail(f"provider check errored: {e}")
 
     print("\nPolicy & credentials")
     cfg = policy.load()

--- a/src/hunch/providers.py
+++ b/src/hunch/providers.py
@@ -1,0 +1,166 @@
+"""provider.py — the LLM provider abstraction for Hunch.
+
+A Provider bundles one vendor's AUTH (login / logout / status) with its AGENT backend,
+so the whole surface is provider-agnostic once chosen at construction:
+
+    mac = hunch.Hunch(provider="codex")     # or "claude" (the default)
+    mac.login()                             # -> the configured provider's sign-in
+    mac.status()                            # -> AuthStatus
+    mac.logout()
+    mac.agent.run("reply to Sarah's email") # -> runs on the configured provider
+
+Standalone, without a Mac instance (e.g. a setup script):
+
+    hunch.provider("codex").login()
+    hunch.provider("claude").status()
+
+Only SUBSCRIPTION / login transports are exposed — metered API keys are intentionally
+left out for now (they add confusion and nobody drives Hunch on their own key). Each
+provider therefore maps to exactly one login-based agent backend.
+
+To add a vendor: subclass Provider, implement login/logout/status/make_backend, and
+register it in PROVIDERS. Nothing else in the SDK needs to learn the new name.
+"""
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+from .errors import HunchError
+
+__all__ = ["Provider", "AuthStatus", "PROVIDERS", "provider", "names"]
+
+
+@dataclass
+class AuthStatus:
+    """A provider's sign-in state, uniform across vendors.
+    method is the transport that authenticates ('subscription' | 'chatgpt' | ...)."""
+    provider: str
+    logged_in: bool
+    method: str | None = None
+    email: str | None = None
+    plan: str | None = None
+
+
+class Provider(ABC):
+    """One LLM vendor: its sign-in flow plus the agent backend it drives Hunch with."""
+
+    name: str = ""
+    extra: str = ""        # the pip extra that installs this provider's agent backend
+
+    # ── auth ────────────────────────────────────────────────────────────────────
+    @abstractmethod
+    def login(self, **kwargs):
+        """Authorize this provider (interactive by default). Returns an AuthStatus."""
+
+    @abstractmethod
+    def logout(self, **kwargs):
+        """Sign this provider out."""
+
+    @abstractmethod
+    def status(self, **kwargs) -> "AuthStatus":
+        """Who, if anyone, is signed in for this provider (explicit check, no scavenging)."""
+
+    def device_login(self, **kwargs):
+        """Headless/remote sign-in, for providers that support it."""
+        raise HunchError(f"the {self.name!r} provider has no device-login flow")
+
+    # ── agent backend ────────────────────────────────────────────────────────────
+    @abstractmethod
+    def make_backend(self, hunch, *, auth=None, app_id=None, can_use_tool=None):
+        """Build the Backend that runs the agent loop for this provider."""
+
+    @classmethod
+    def deps_installed(cls):
+        """True when this provider's agent backend dependency is importable."""
+        return False
+
+
+class ClaudeProvider(Provider):
+    """Anthropic Claude on the user's subscription (claude-agent-sdk + hunch.login sign-in)."""
+
+    name = "claude"
+    extra = "subscription"
+
+    def login(self, token=None, app_id=None):
+        from . import auth
+        return _from_claude(auth.login(token=token, app_id=app_id))
+
+    def logout(self, app_id=None):
+        from . import auth
+        return auth.logout(app_id=app_id)
+
+    def status(self, app_id=None):
+        from . import auth
+        return _from_claude(auth.status(app_id=app_id))
+
+    def make_backend(self, hunch, *, auth=None, app_id=None, can_use_tool=None):
+        from .agent import SubscriptionBackend
+        from .auth import OAuthToken
+        token = auth if isinstance(auth, OAuthToken) else None
+        return SubscriptionBackend(hunch, auth=token, app_id=app_id, can_use_tool=can_use_tool)
+
+    @classmethod
+    def deps_installed(cls):
+        from .agent import SubscriptionBackend
+        return SubscriptionBackend.deps_installed()
+
+
+class CodexProvider(Provider):
+    """OpenAI Codex on a `codex login` (ChatGPT) session (the openai-codex SDK)."""
+
+    name = "codex"
+    extra = "codex"
+
+    def login(self, **kwargs):
+        from . import auth
+        return _from_codex(auth.codex_login())          # ChatGPT browser sign-in
+
+    def device_login(self, **kwargs):
+        from . import auth
+        return auth.codex_device_login()                 # returns the SDK's device handle
+
+    def logout(self, **kwargs):
+        from . import auth
+        return auth.codex_logout()
+
+    def status(self, **kwargs):
+        from . import auth
+        return _from_codex(auth.codex_status())
+
+    def make_backend(self, hunch, *, auth=None, app_id=None, can_use_tool=None):
+        from .backends.codex import CodexBackend
+        return CodexBackend(hunch, app_id=app_id, can_use_tool=can_use_tool)
+
+    @classmethod
+    def deps_installed(cls):
+        from .backends.codex import CodexBackend
+        return CodexBackend.deps_installed()
+
+
+PROVIDERS = {"claude": ClaudeProvider, "codex": CodexProvider}
+
+
+def names():
+    return tuple(PROVIDERS)
+
+
+def provider(name):
+    """The Provider for a name ('claude' | 'codex'), usable standalone:
+    hunch.provider('codex').login()."""
+    cls = PROVIDERS.get(name)
+    if cls is None:
+        raise HunchError(f"unknown provider {name!r} — use "
+                         + ", ".join(repr(n) for n in PROVIDERS))
+    return cls()
+
+
+# ── adapters: vendor-specific status -> the uniform AuthStatus ──────────────────
+def _from_claude(st):
+    return AuthStatus("claude", bool(getattr(st, "subscription_ready", False)),
+                      "subscription" if getattr(st, "subscription_ready", False) else None,
+                      getattr(st, "email", None), getattr(st, "plan", None))
+
+
+def _from_codex(st):
+    return AuthStatus("codex", bool(getattr(st, "logged_in", False)),
+                      getattr(st, "method", None), getattr(st, "email", None),
+                      getattr(st, "plan", None))

--- a/src/hunch/sdk.py
+++ b/src/hunch/sdk.py
@@ -59,16 +59,22 @@ class Hunch:
     def __init__(self, app="Finder", confirm="dialog", check_permissions=True,
                  simultaneous=False, cdp_port=None,
                  snapshot_max_depth=None, snapshot_max_nodes=None,
-                 agent_backend="auto", auth=None, app_name=None, policy=None,
+                 provider="claude", auth=None, can_use_tool=None, app_name=None, policy=None,
                  app_id=None, cdp_profile=None, notify=None):
-        """agent_backend: which LLM transport `mac.agent` uses — 'api' (anthropic SDK on a
-        metered ANTHROPIC_API_KEY), 'subscription' (claude-agent-sdk on the hunch.login()
-        Claude sign-in), or 'auto' (pick by credentials). Overridable per call via
-        mac.agent.run(..., backend=...).
+        """provider: which LLM vendor drives the agent loop — 'claude' (Anthropic, on your
+        Claude sign-in; the default) or 'codex' (OpenAI Codex, on a `codex login` session).
+        Set once here; then mac.login() / mac.status() / mac.logout() and mac.agent all act
+        on it — no provider prefix. Both drive Hunch on a subscription/login (API keys are
+        intentionally not exposed).
 
-        auth: the agent loop's credential — None (ambient resolution, hunch.auth order),
-        hunch.ApiKey(...) / hunch.OAuthToken(...) (use exactly this credential, nothing
-        ambient), or 'none' (never scavenge; the loop raises until a credential is given).
+        auth: an explicit injected credential for the provider, or None to use its own stored
+        sign-in. For 'claude' this is hunch.OAuthToken(...) (the subscription token the app
+        mints); 'codex' takes no injected credential (authenticate with mac.login() /
+        `codex login`).
+
+        can_use_tool: optional host-owned permission callback (tool_name, input, context) ->
+        Allow/Deny, handed to the provider's backend so a host app can route every tool
+        through its own Approve/Deny UI.
 
         confirm: 'dialog' (osascript click-to-approve), 'off' (auto-approve everything),
         or a callable(ConsentRequest) -> bool to render consent in YOUR app's UI.
@@ -111,20 +117,21 @@ class Hunch:
             self._gate = gate.Gate(confirm=confirm, app_name=self.app_name, policy=policy)
         except ValueError as e:
             raise HunchError(str(e)) from None
-        if agent_backend not in ("auto", "api", "subscription"):
-            raise HunchError(f"unknown agent_backend {agent_backend!r} — "
-                             "use 'api', 'subscription', or 'auto'")
-        from .auth import ApiKey, OAuthToken
-        if not (auth is None or auth == "none" or isinstance(auth, (ApiKey, OAuthToken))):
-            raise HunchError(f"unknown auth {auth!r} — pass hunch.ApiKey(...), "
-                             "hunch.OAuthToken(...), 'none', or None (ambient)")
-        if isinstance(auth, ApiKey) and agent_backend == "subscription":
-            raise HunchError("auth=ApiKey(...) implies the 'api' backend, "
-                             "but agent_backend='subscription' was requested")
-        if isinstance(auth, OAuthToken) and agent_backend == "api":
-            raise HunchError("auth=OAuthToken(...) implies the 'subscription' backend, "
-                             "but agent_backend='api' was requested")
+        from . import providers as _provider_mod
+        if provider not in _provider_mod.PROVIDERS:
+            raise HunchError(f"unknown provider {provider!r} — use "
+                             + ", ".join(repr(n) for n in _provider_mod.PROVIDERS))
+        from .auth import OAuthToken
+        if not (auth is None or isinstance(auth, OAuthToken)):
+            raise HunchError(f"unknown auth {auth!r} — pass hunch.OAuthToken(...) (the Claude "
+                             "subscription token) or None; authenticate codex with mac.login()")
+        if isinstance(auth, OAuthToken) and provider != "claude":
+            raise HunchError("auth=OAuthToken(...) is a Claude credential, but "
+                             f"provider={provider!r} was requested")
+        self._provider_name = provider
+        self._provider = _provider_mod.provider(provider)
         self._agent_auth = auth
+        self._can_use_tool = can_use_tool
         if check_permissions:
             self._check_accessibility()
         # ONE persistent computer per instance, so element [refs] survive snapshot -> act.
@@ -142,7 +149,6 @@ class Hunch:
         self.files = Files(self)
         self.clipboard = Clipboard(self)
         self._agent = None   # the agent loop, created lazily so the LLM SDKs stay optional
-        self._agent_backend = agent_backend
 
     @staticmethod
     def _check_accessibility():
@@ -296,18 +302,39 @@ class Hunch:
             parts.append("API keys/secrets (web.fill_secret): " + ", ".join(secrets))
         return "Saved credentials — " + "; ".join(parts)
 
-    # ── agent loop ────────────────────────────────────────────────────
+    # ── provider (auth + agent loop) ──────────────────────────────────────────
+
+    @property
+    def provider(self):
+        """The configured LLM provider ('claude' | 'codex'), as a Provider object.
+        Usually you go through mac.login()/status()/logout()/agent instead."""
+        return self._provider
+
+    def login(self, **kwargs):
+        """Sign in to the configured provider (interactive) — claude: your Claude sign-in;
+        codex: a ChatGPT/Codex browser sign-in. Returns an AuthStatus."""
+        return self._provider.login(app_id=self._app_id, **kwargs) \
+            if self._provider_name == "claude" else self._provider.login(**kwargs)
+
+    def logout(self, **kwargs):
+        """Sign the configured provider out."""
+        return self._provider.logout(app_id=self._app_id, **kwargs) \
+            if self._provider_name == "claude" else self._provider.logout(**kwargs)
+
+    def status(self, **kwargs):
+        """Who, if anyone, is signed in for the configured provider (an AuthStatus)."""
+        return self._provider.status(app_id=self._app_id, **kwargs) \
+            if self._provider_name == "claude" else self._provider.status(**kwargs)
 
     @property
     def agent(self):
         """The agent loop: `mac.agent.run(task=...)` runs an LLM loop that drives this Mac
-        through these primitives. Two backends (pip install 'hunch-sdk[agent]' brings both):
-        your Claude subscription after hunch.login(), or a metered ANTHROPIC_API_KEY.
-        Chosen at construction via Hunch(agent_backend=...), by credentials on 'auto', or
-        per call via run(backend=...). Created lazily so plain use imports neither SDK."""
+        through these primitives, on the provider chosen at construction (Hunch(provider=...)).
+        Created lazily so plain use imports none of the LLM SDKs."""
         if self._agent is None:
             from .agent import Agent
-            self._agent = Agent(self, backend=self._agent_backend, auth=self._agent_auth)
+            self._agent = Agent(self, provider=self._provider, auth=self._agent_auth,
+                                can_use_tool=self._can_use_tool)
         return self._agent
 
     # ── lifecycle ─────────────────────────────────────────────────────────────

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -8,7 +8,7 @@ import sys
 import types
 
 import hunch.agent as agent_mod
-from hunch.agent import Agent, AgentResult, AGENT_TOOLS, _run_tool, _mark_cache
+from hunch.agent import Agent, AgentResult, AGENT_TOOLS, ApiBackend, _run_tool, _mark_cache
 from hunch.gate import ApprovalDenied
 
 
@@ -100,7 +100,8 @@ class _FakeHunch:
 
 
 def _agent(script, hunch=None):
-    return Agent(hunch or _FakeHunch(), client=_FakeClient(script))
+    # The api backend is dormant (not provider-exposed) but kept; its loop is tested directly.
+    return ApiBackend(hunch or _FakeHunch(), client=_FakeClient(script))
 
 
 # ── tests ─────────────────────────────────────────────────────────────────────
@@ -250,9 +251,9 @@ def test_thinking_and_effort_passthrough():
 
 def test_missing_anthropic_error(monkeypatch):
     monkeypatch.setitem(sys.modules, "anthropic", None)   # import anthropic -> ImportError
-    a = Agent(_FakeHunch(), client=None)                  # no injected client -> must import
+    a = ApiBackend(_FakeHunch(), client=None)             # no injected client -> must import
     try:
-        a.run("x", backend="api")                         # pin: auto may pick subscription here
+        a.run("x")
         assert False, "expected HunchError"
     except agent_mod.HunchError as e:
         assert "hunch-sdk[agent]" in str(e)
@@ -283,24 +284,32 @@ def test_mcp_image_shape():
     assert out["content"][0] == {"type": "text", "text": "boom"} and out["is_error"] is True
 
 
-def test_backend_resolution(monkeypatch):
-    import hunch.auth as auth
-    a = Agent(_FakeHunch())
-    assert a._resolve_backend("api") == "api"                    # explicit wins
-    assert a._resolve_backend("subscription") == "subscription"
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
-    assert a._resolve_backend("auto") == "api"                   # API key -> api
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-    monkeypatch.setitem(sys.modules, "claude_agent_sdk", types.ModuleType("claude_agent_sdk"))
-    monkeypatch.setattr(auth, "subscription_available", lambda app_id=None: True)
-    assert a._resolve_backend("auto") == "subscription"          # signed in -> subscription
-    monkeypatch.setattr(auth, "subscription_available", lambda app_id=None: False)
+def test_agent_delegates_to_provider_backend():
+    """Agent builds its backend from the configured provider and delegates run to it."""
+    calls = {}
+
+    class _FakeBackend:
+        def run(self, task, **kw): calls["ran"] = task; return AgentResult("ok", 1, "end_turn")
+
+    class _FakeProvider:
+        name = "codex"
+        def make_backend(self, hunch, *, auth=None, app_id=None, can_use_tool=None):
+            calls["made"] = True
+            return _FakeBackend()
+
+    a = Agent(_FakeHunch(), provider=_FakeProvider())
+    assert a.provider == "codex"
+    r = a.run("do it")
+    assert calls == {"made": True, "ran": "do it"} and r.text == "ok"
+
+
+def test_agent_without_provider_raises():
+    a = Agent(_FakeHunch(), provider=None)
     try:
-        a._resolve_backend("auto")
+        a.run("x")
         assert False, "expected HunchError"
-    except agent_mod.HunchError as e:                            # nothing -> both fixes named
-        assert "hunch.login()" in str(e) and "ANTHROPIC_API_KEY" in str(e)
-    assert Agent(_FakeHunch(), client=_FakeClient([]))._resolve_backend("auto") == "api"
+    except agent_mod.HunchError as e:
+        assert "no provider" in str(e)
 
 
 def test_subscription_missing_sdk(monkeypatch):
@@ -433,21 +442,28 @@ def test_subscription_default_permit_is_hunch_only():
     assert type(allow).__name__ == "PermissionResultAllow"
 
 
-def test_agent_forwards_can_use_tool_to_subscription():
+def test_agent_forwards_can_use_tool():
     async def permit(tool_name, input_data, context):
         return "ALLOWED"
     a = Agent(_FakeHunch(), can_use_tool=permit)
-    assert a._can_use_tool is permit
+    assert a._can_use_tool is permit    # handed to the provider's backend at build time
 
 
-def test_agent_interrupt_sets_abort_and_delegates():
+def test_agent_interrupt_delegates_to_active_backend():
     a = Agent(_FakeHunch())
-    a.interrupt()                     # no subscription runner yet -> just arms the api abort flag
-    assert a._abort is True
+    a.interrupt()                     # no active backend yet -> no-op, must not raise
     calls = []
-    a._sub = types.SimpleNamespace(interrupt=lambda: calls.append("i"))
+    a._backend = types.SimpleNamespace(interrupt=lambda: calls.append("i"))
     a.interrupt()
-    assert calls == ["i"]             # delegates to the subscription runner when present
+    assert calls == ["i"]             # delegates to whatever backend is currently active
+
+
+def test_api_backend_interrupt_arms_abort():
+    from hunch.agent import ApiBackend
+    b = ApiBackend(_FakeHunch())
+    assert b._abort is False
+    b.interrupt()
+    assert b._abort is True           # the api loop checks this between turns
 
 
 # ── auth resolution (the hunch.login() surface) ─────────────────────────────────
@@ -508,11 +524,11 @@ def test_auth_login_token_and_failure(monkeypatch):
         assert "browser flow failed" in str(e)
 
 
-def test_top_level_auth_exports_stay_light():
-    """hunch.login/logout/AuthStatus and the exceptions must not pull pyobjc."""
+def test_top_level_exports_stay_light():
+    """hunch.provider/AuthStatus/OAuthToken and the exceptions must not pull pyobjc."""
     import subprocess
     code = ("import sys, hunch; "
-            "hunch.AuthStatus, hunch.login, hunch.logout, hunch.HunchError; "
+            "hunch.provider, hunch.AuthStatus, hunch.OAuthToken, hunch.HunchError; "
             "sys.exit(1 if any(m in sys.modules for m in ('AppKit', 'Quartz')) else 0)")
     assert subprocess.run([sys.executable, "-c", code]).returncode == 0
 
@@ -554,43 +570,12 @@ def test_token_service_namespacing(monkeypatch):
 
 
 def test_injected_credential_reprs_redact():
-    from hunch.auth import ApiKey, OAuthToken
+    from hunch.auth import ApiKey, OAuthToken   # ApiKey stays for the dormant api backend
     assert "sk-ant-supersecret" not in repr(ApiKey("sk-ant-supersecret"))
     assert "sk-ant-oat-supersecret" not in repr(OAuthToken("sk-ant-oat-supersecret"))
 
 
-def test_auth_injection_backend_rules(monkeypatch):
-    from hunch.auth import ApiKey, OAuthToken
-    # injected credential implies its backend, beating ambient state entirely
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-    assert Agent(_FakeHunch(), auth=ApiKey("k"))._resolve_backend(None) == "api"
-    assert Agent(_FakeHunch(), auth=OAuthToken("t"))._resolve_backend(None) == "subscription"
-    # contradictions fail fast — at construction and per-run
-    try:
-        Agent(_FakeHunch(), auth=ApiKey("k"), backend="subscription")
-        assert False, "expected HunchError"
-    except agent_mod.HunchError as e:
-        assert "implies" in str(e)
-    try:
-        Agent(_FakeHunch(), auth=OAuthToken("t"))._resolve_backend("api")
-        assert False, "expected HunchError"
-    except agent_mod.HunchError as e:
-        assert "implies" in str(e)
-    # auth="none": ambient disabled, no injected credential -> explicit error
-    try:
-        Agent(_FakeHunch(), auth="none")._resolve_backend(None)
-        assert False, "expected HunchError"
-    except agent_mod.HunchError as e:
-        assert "ambient" in str(e)
-    # bad auth value fails at construction
-    try:
-        Agent(_FakeHunch(), auth="gpt-key")
-        assert False, "expected HunchError"
-    except agent_mod.HunchError as e:
-        assert "auth" in str(e)
-
-
-def test_ensure_client_uses_injected_api_key(monkeypatch):
+def test_api_backend_ensure_client_uses_injected_api_key(monkeypatch):
     from hunch.auth import ApiKey
     captured = {}
 
@@ -601,7 +586,7 @@ def test_ensure_client_uses_injected_api_key(monkeypatch):
     fake = types.ModuleType("anthropic")
     fake.Anthropic = _FakeAnthropicClient
     monkeypatch.setitem(sys.modules, "anthropic", fake)
-    a = Agent(_FakeHunch(), auth=ApiKey("sk-test-inject"))
+    a = ApiBackend(_FakeHunch(), auth=ApiKey("sk-test-inject"))
     a._ensure_client()
     assert captured == {"api_key": "sk-test-inject"}
 
@@ -623,24 +608,23 @@ def test_cli_env_injected_and_ambient(monkeypatch):
     assert "CLAUDE_CODE_OAUTH_TOKEN" not in os.environ
 
 
-def test_hunch_constructor_auth_validation():
+def test_hunch_provider_and_auth_validation():
     from hunch.sdk import Hunch
-    from hunch.auth import ApiKey, OAuthToken
-    h = Hunch(check_permissions=False, confirm="off", auth=ApiKey("k"))
-    assert h.agent._resolve_backend(None) == "api"       # implied by the injected key
-    try:
-        Hunch(check_permissions=False, confirm="off",
-              auth=ApiKey("k"), agent_backend="subscription")
+    from hunch.auth import OAuthToken
+    assert Hunch(check_permissions=False, confirm="off").provider.name == "claude"  # default
+    Hunch(check_permissions=False, confirm="off", provider="claude", auth=OAuthToken("t"))
+    for bad in ("gpt", "openai", "api"):
+        try:
+            Hunch(check_permissions=False, confirm="off", provider=bad)
+            assert False, "expected HunchError"
+        except agent_mod.HunchError as e:
+            assert "unknown provider" in str(e)
+    try:                                 # OAuthToken is a Claude credential
+        Hunch(check_permissions=False, confirm="off", provider="codex", auth=OAuthToken("t"))
         assert False, "expected HunchError"
     except agent_mod.HunchError as e:
-        assert "implies" in str(e)
-    try:
-        Hunch(check_permissions=False, confirm="off",
-              auth=OAuthToken("t"), agent_backend="api")
-        assert False, "expected HunchError"
-    except agent_mod.HunchError as e:
-        assert "implies" in str(e)
-    try:
+        assert "Claude credential" in str(e)
+    try:                                 # unknown auth value fails fast
         Hunch(check_permissions=False, confirm="off", auth=12345)
         assert False, "expected HunchError"
     except agent_mod.HunchError as e:
@@ -649,28 +633,12 @@ def test_hunch_constructor_auth_validation():
 
 def test_lazy_agent_property():
     from hunch.sdk import Hunch
-    h = Hunch(check_permissions=False, confirm="off")
+    h = Hunch(check_permissions=False, confirm="off", provider="codex")
     assert h._agent is None                    # not created eagerly
     a1 = h.agent
     a2 = h.agent
     assert a1 is a2 and isinstance(a1, Agent)   # same instance, lazily created
-    assert a1.backend == "auto"                 # the default
-
-
-def test_agent_backend_constructor_option():
-    """Developers choose the backend when constructing the instance; run(backend=)
-    still overrides per call, and a bad value fails fast at construction."""
-    from hunch.sdk import Hunch
-    h = Hunch(check_permissions=False, confirm="off", agent_backend="subscription")
-    assert h.agent.backend == "subscription"
-    assert h.agent._resolve_backend(None) == "subscription"    # constructor default used
-    assert h.agent._resolve_backend("api") == "api"            # per-run override wins
-    assert Agent(_FakeHunch(), backend="api").backend == "api" # direct construction too
-    try:
-        Hunch(check_permissions=False, confirm="off", agent_backend="gpt")
-        assert False, "expected HunchError"
-    except agent_mod.HunchError as e:
-        assert "agent_backend" in str(e)
+    assert a1.provider == "codex"               # bound to the constructed provider
 
 
 if __name__ == "__main__":

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -1,0 +1,285 @@
+"""Codex backend + provider-abstraction tests.
+
+Covers the provider layer (hunch.provider / ClaudeProvider / CodexProvider), the codex
+agent backend (no API-key path, no credential detection), and the codex auth surface —
+all with fakes around the one live SDK touch-point. A final block asserts the shapes we
+depend on exist in the installed openai-codex (guards against beta drift).
+"""
+import sys
+import types
+
+import pytest
+
+from hunch.agent import Agent, ApiBackend, SubscriptionBackend, AgentResult
+from hunch.backends import NAMES, get
+from hunch.backends.codex import CodexBackend
+from hunch.providers import provider, PROVIDERS, ClaudeProvider, CodexProvider, AuthStatus
+from hunch.errors import HunchError
+
+
+class _FakeHunch:
+    def __init__(self):
+        self._app_id = None
+
+
+# ── provider registry ─────────────────────────────────────────────────────────
+def test_provider_registry():
+    assert set(PROVIDERS) == {"claude", "codex"}
+    assert isinstance(provider("claude"), ClaudeProvider)
+    assert isinstance(provider("codex"), CodexProvider)
+
+
+def test_provider_unknown_raises():
+    with pytest.raises(HunchError) as e:
+        provider("gpt")
+    assert "unknown provider" in str(e.value)
+
+
+def test_provider_metadata_and_backends():
+    assert (ClaudeProvider.name, ClaudeProvider.extra) == ("claude", "subscription")
+    assert (CodexProvider.name, CodexProvider.extra) == ("codex", "codex")
+    assert isinstance(CodexProvider().make_backend(_FakeHunch()), CodexBackend)
+    assert isinstance(ClaudeProvider().make_backend(_FakeHunch()), SubscriptionBackend)
+
+
+def test_claude_make_backend_passes_oauth_token():
+    from hunch.auth import OAuthToken
+    be = ClaudeProvider().make_backend(_FakeHunch(), auth=OAuthToken("tok-1"))
+    assert be._auth.value == "tok-1"                       # forwarded to the subscription backend
+
+
+# ── codex backend: no API keys, no credential detection ──────────────────────────
+def test_codex_backend_metadata():
+    assert (CodexBackend.name, CodexBackend.provider, CodexBackend.extra) == \
+        ("codex", "openai", "codex")
+    assert CodexBackend.default_model is None
+
+
+def test_codex_available_is_deps_only(monkeypatch):
+    assert not hasattr(CodexBackend, "_credential_present")   # detection removed
+    assert not hasattr(CodexBackend, "_api_key")             # API-key path removed
+    monkeypatch.setattr(CodexBackend, "deps_installed", classmethod(lambda cls: True))
+    assert CodexBackend.available() is True
+    monkeypatch.setattr(CodexBackend, "deps_installed", classmethod(lambda cls: False))
+    assert CodexBackend.available() is False
+
+
+def test_codex_run_without_sdk_raises(monkeypatch):
+    monkeypatch.setattr(CodexBackend, "deps_installed", classmethod(lambda cls: False))
+    with pytest.raises(HunchError) as e:
+        CodexBackend(_FakeHunch()).run("do it")
+    assert "openai-codex" in str(e.value) and "--pre" in str(e.value)
+
+
+def test_codex_run_unauthenticated_hints_login(monkeypatch, tmp_path):
+    monkeypatch.setattr(CodexBackend, "deps_installed", classmethod(lambda cls: True))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    b = CodexBackend(_FakeHunch())
+    monkeypatch.setattr(b, "_open_thread",
+                        lambda model, cwd: (_ for _ in ()).throw(RuntimeError("401 please login")))
+    events = []
+    r = b.run("x", on_event=lambda k, d: events.append((k, d)))
+    assert r.aborted is True
+    assert any(k == "error" and "login" in d for k, d in events)
+
+
+def test_codex_config_overrides_register_hunch_server():
+    ov = CodexBackend(_FakeHunch())._config_overrides()
+    assert isinstance(ov, tuple)
+    joined = "\n".join(ov)
+    assert "mcp_servers.hunch.command=" in joined
+    assert 'mcp_servers.hunch.args=["-m", "hunch", "serve"]' in joined
+    assert "mcp_servers.hunch.env.HOME=" in joined and "mcp_servers.hunch.env.PATH=" in joined
+
+
+def test_codex_instructions_carry_playbook():
+    import hunch.playbook as playbook
+    text = CodexBackend(_FakeHunch())._instructions()
+    assert "controlling this Mac" in text and playbook.HUNCH_PLAYBOOK in text
+
+
+def test_codex_working_dir_is_private(monkeypatch, tmp_path):
+    import os
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    d = CodexBackend(_FakeHunch())._working_dir()
+    assert os.path.isdir(d) and str(tmp_path) in d
+
+
+# ── codex result translation (TurnResult.items -> on_event) ───────────────────────
+def _item(**kw):
+    return types.SimpleNamespace(root=types.SimpleNamespace(**kw))
+
+
+def test_codex_emit_item():
+    events = []
+    emit = lambda k, d: events.append((k, d))
+    assert CodexBackend._emit_item(_item(type="mcpToolCall", tool="snapshot",
+                                         arguments={"app": "Mail"}, result="ok"), emit) == ""
+    assert ("tool", {"name": "snapshot", "input": {"app": "Mail"}}) in events
+    assert ("tool_result", "ok") in events
+    events.clear()
+    assert CodexBackend._emit_item(_item(type="agentMessage", text="done"), emit) == "done"
+    assert events == [("text", "done")]
+
+
+class _FakeTurn:
+    def __init__(self, items, final_response="", error=None, usage=None):
+        self.items = items
+        self.final_response = final_response
+        self.error = error
+        self.usage = usage
+
+
+def _prep_codex(monkeypatch, tmp_path):
+    monkeypatch.setattr(CodexBackend, "deps_installed", classmethod(lambda cls: True))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+
+
+def test_codex_run_streams_and_returns_result(monkeypatch, tmp_path):
+    _prep_codex(monkeypatch, tmp_path)
+    b = CodexBackend(_FakeHunch())
+    monkeypatch.setattr(b, "_open_thread", lambda model, cwd: "THREAD")
+    turn = _FakeTurn(items=[_item(type="mcpToolCall", tool="act", arguments={}, result=None),
+                            _item(type="agentMessage", text="sent it")],
+                     final_response="sent it")
+    monkeypatch.setattr(b, "_run_turn", lambda thread, task: turn)
+    events = []
+    r = b.run("send it", on_event=lambda k, d: events.append(k))
+    assert r.text == "sent it" and r.aborted is False and r.stop_reason == "end_turn"
+    assert events == ["tool", "text", "done"]
+
+
+def test_codex_run_error_field(monkeypatch, tmp_path):
+    _prep_codex(monkeypatch, tmp_path)
+    b = CodexBackend(_FakeHunch())
+    monkeypatch.setattr(b, "_open_thread", lambda model, cwd: "THREAD")
+    monkeypatch.setattr(b, "_run_turn", lambda t, task: _FakeTurn(items=[], error="rate limited"))
+    events = []
+    r = b.run("x", on_event=lambda k, d: events.append((k, d)))
+    assert r.aborted is True and r.stop_reason == "error"
+    assert ("error", "rate limited") in events
+
+
+# ── codex auth surface (via the provider), faking the openai_codex SDK ─────────────
+def _fake_openai_codex(account_kind=None, requires_auth=False):
+    mod = types.ModuleType("openai_codex")
+    calls = {"chatgpt": 0, "device": 0, "logout": 0}
+
+    class _Handle:
+        auth_url = "https://auth.example/authorize"
+        verification_url = "https://auth.example/device"
+        user_code = "WXYZ-7788"
+
+        def wait(self):
+            return "done"
+
+    def _acct_root():
+        if account_kind is None:
+            return None
+        obj = type(account_kind, (), {})()          # class NAME is the discriminator
+        obj.__dict__.update(email="me@example.com", plan_type="pro")
+        return obj
+
+    class _Codex:
+        def login_chatgpt(self): calls["chatgpt"] += 1; return _Handle()
+        def login_chatgpt_device_code(self): calls["device"] += 1; return _Handle()
+        def logout(self): calls["logout"] += 1
+        def account(self, refresh_token=False):
+            return types.SimpleNamespace(requires_openai_auth=requires_auth,
+                                         account=types.SimpleNamespace(root=_acct_root()))
+
+    mod.Codex = _Codex
+    return mod, calls
+
+
+def test_codex_provider_login_and_status(monkeypatch):
+    # requires_auth=True mirrors reality: a signed-in ChatGPT account still reports it.
+    fake, calls = _fake_openai_codex(account_kind="ChatgptAccount", requires_auth=True)
+    monkeypatch.setitem(sys.modules, "openai_codex", fake)
+    st = provider("codex").login()
+    assert calls["chatgpt"] == 1
+    assert isinstance(st, AuthStatus) and st.provider == "codex" and st.logged_in
+    assert st.method == "chatgpt" and st.email == "me@example.com" and st.plan == "pro"
+
+
+def test_codex_provider_device_login_and_logout(monkeypatch):
+    fake, calls = _fake_openai_codex()
+    monkeypatch.setitem(sys.modules, "openai_codex", fake)
+    handle = provider("codex").device_login()
+    assert calls["device"] == 1 and handle.user_code == "WXYZ-7788"
+    provider("codex").logout()
+    assert calls["logout"] == 1
+
+
+def test_codex_provider_status_logged_out(monkeypatch):
+    fake, _ = _fake_openai_codex(account_kind=None)      # no account.root -> logged out
+    monkeypatch.setitem(sys.modules, "openai_codex", fake)
+    st = provider("codex").status()
+    assert st.provider == "codex" and st.logged_in is False
+
+
+def test_codex_provider_login_without_sdk_raises(monkeypatch):
+    monkeypatch.setitem(sys.modules, "openai_codex", None)   # import -> ImportError
+    with pytest.raises(HunchError) as e:
+        provider("codex").login()
+    assert "openai-codex" in str(e.value)
+
+
+# ── claude provider auth delegates to the (unchanged) claude auth module ──────────
+def test_claude_provider_status(monkeypatch):
+    import hunch.auth as auth
+    monkeypatch.setattr(auth, "status",
+                        lambda app_id=None: types.SimpleNamespace(
+                            subscription_ready=True, email="dev@x.com", plan="max"))
+    st = provider("claude").status()
+    assert st.provider == "claude" and st.logged_in and st.method == "subscription"
+    assert st.email == "dev@x.com" and st.plan == "max"
+
+
+# ── Hunch integration: provider drives auth + the agent loop ──────────────────────
+def test_hunch_provider_selection():
+    from hunch.sdk import Hunch
+    h = Hunch(check_permissions=False, confirm="off", provider="codex")
+    assert h.provider.name == "codex" and h.agent.provider == "codex"
+    assert isinstance(h.agent._backend_(), CodexBackend)   # agent uses the provider's backend
+
+
+def test_hunch_login_dispatches_to_provider(monkeypatch):
+    from hunch.sdk import Hunch
+    fake, calls = _fake_openai_codex(account_kind="ChatgptAccount", requires_auth=True)
+    monkeypatch.setitem(sys.modules, "openai_codex", fake)
+    h = Hunch(check_permissions=False, confirm="off", provider="codex")
+    st = h.login()                                          # no provider prefix
+    assert calls["chatgpt"] == 1 and st.provider == "codex" and st.logged_in
+
+
+# ── real-SDK shape guards (skip if openai-codex isn't installed) ───────────────────
+def test_sdk_shape_matches_backend_assumptions():
+    oc = pytest.importorskip("openai_codex")
+    import inspect
+    import dataclasses
+    params = inspect.signature(oc.Codex.thread_start).parameters
+    for p in ("cwd", "developer_instructions", "config", "model", "sandbox"):
+        assert p in params, f"thread_start lost {p!r}"
+    assert hasattr(oc.Sandbox, "workspace_write")
+    turn_fields = {f.name for f in dataclasses.fields(oc.TurnResult)}
+    for f in ("items", "final_response", "error", "usage"):
+        assert f in turn_fields
+    # auth methods the provider relies on
+    for m in ("login_chatgpt", "login_chatgpt_device_code", "logout", "account"):
+        assert hasattr(oc.Codex, m)
+
+
+def test_sdk_accepts_our_config_overrides():
+    oc = pytest.importorskip("openai_codex")
+    oc.CodexConfig(config_overrides=CodexBackend(_FakeHunch())._config_overrides())
+
+
+def test_sdk_item_variant_fields_match():
+    pytest.importorskip("openai_codex")
+    import typing
+    from openai_codex.generated import v2_all as v
+    mcp = v.McpToolCallThreadItem.model_fields
+    assert "tool" in mcp and "arguments" in mcp and "result" in mcp
+    assert typing.get_args(mcp["type"].annotation) == ("mcpToolCall",)
+    assert typing.get_args(v.AgentMessageThreadItem.model_fields["type"].annotation) == ("agentMessage",)


### PR DESCRIPTION
## Summary

Adds a **provider abstraction** so the LLM vendor is chosen **once** at construction, after which auth *and* the agent loop are provider-agnostic — no more per-call provider prefixes (`codex_login` vs `login`).

```python
mac = hunch.Hunch(provider="codex")   # or "claude" (default)
mac.login(); mac.status(); mac.logout()
mac.agent.run("reply to Sarah's email")     # runs on the configured provider
hunch.provider("codex").login()             # standalone, no Mac instance
```

Ships the **OpenAI Codex** provider (for people who live in Codex, not Claude Code) alongside Claude — validated live driving the Mac on a ChatGPT/Codex subscription.

## What changed
- **New `hunch.providers`**: `Provider` ABC + `ClaudeProvider`/`CodexProvider` + `provider(name)` factory + unified `AuthStatus`. Each provider bundles its auth (login/logout/status) and its agent backend.
- **New `hunch.backends` package**: `Backend` ABC + registry; `SubscriptionBackend` (Claude), `CodexBackend` (Codex, drives the openai-codex SDK with Hunch tools attached over MCP), and a **dormant** `ApiBackend`.
- `Agent` is now provider-driven (no backend selection).
- `Hunch(provider=…, auth=…, can_use_tool=…)`; `mac.login/status/logout` dispatch to the provider; `hunch doctor` is provider-oriented.
- README, examples, and pyproject extras updated. Version → **0.6.0**.

## ⚠️ Breaking (0.6.0)
Removed: `hunch.login`/`logout`, `codex_login`/`logout`/`device_login`, `ApiKey`, `OpenAIKey`, `Hunch(agent_backend=)`, `mac.agent.run(backend=)`, the user-facing `api` backend. **Kept** `OAuthToken` (the Claude *subscription* token) and `HunchError`.

**Subscription/login only** — metered API keys are intentionally not exposed for now (they added confusion; the `api` backend stays dormant internally so it can return without a rewrite).

The Hunch app (`app/hunch_agent.py`, separate repo) has been migrated to `Hunch(provider="claude", …)` and its pin bumped to `>=0.6.0`.

## Verification
- 136 tests pass (incl. real-SDK shape guards against the installed `openai-codex`)
- Wheel builds; clean-venv install imports the full surface; `[codex]` extra resolves
- Live end-to-end: `Hunch(provider="codex").agent.run(...)` drove `list_apps`/`applescript` correctly on a ChatGPT session

🤖 Generated with [Claude Code](https://claude.com/claude-code)