### PR TITLE
ci: auto-publish hunch-sdk to PyPI on version bump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,69 @@
+name: Publish to PyPI
+
+# Fires on merges to main that touch the package or its version.
+# It only publishes when pyproject's version is one PyPI does NOT already have,
+# so a merge that didn't bump the version is a safe no-op (PyPI rejects re-uploads).
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/hunch/**"
+      - "pyproject.toml"
+      - "README.md"
+  workflow_dispatch: {}   # allow manual runs from the Actions tab
+
+jobs:
+  check:
+    name: Should we publish?
+    runs-on: ubuntu-latest
+    outputs:
+      publish: ${{ steps.decide.outputs.publish }}
+      version: ${{ steps.decide.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: decide
+        run: |
+          set -euo pipefail
+          VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          # 200 => this version already exists on PyPI; anything else => new.
+          CODE=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/hunch-sdk/$VERSION/json")
+          if [ "$CODE" = "200" ]; then
+            echo "hunch-sdk $VERSION already on PyPI — skipping."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "hunch-sdk $VERSION is new — will publish."
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  publish:
+    name: Build & publish
+    needs: check
+    if: needs.check.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/hunch-sdk
+    permissions:
+      id-token: write      # OIDC token for PyPI Trusted Publishing
+      contents: write      # create the git tag / release
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build sdist + wheel
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Tag the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          V="v${{ needs.check.outputs.version }}"
+          git tag "$V"
+          git push origin "$V"
+          gh release create "$V" dist/* --title "$V" --generate-notes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,7 +173,14 @@ Use **`_frontmost()`** (`local_mac.py`) — a fresh `lsappinfo` query per call. 
   (capital P), or publishing 403s.
 - **`server.json`** (repo root) is the MCP-registry manifest; **`mcp.json`** (repo root) is the Open
   Plugins / Cursor-directory manifest. Bump `server.json`'s `version` alongside `pyproject.toml`.
-- **Publishing order:** release to PyPI first (`uv build` then `uv publish`), then
+- **PyPI publishing is automated.** `.github/workflows/publish.yml` fires on merge to `main` when
+  `src/hunch/**` or `pyproject.toml` changed, and publishes **only if** the `pyproject.toml` version
+  isn't already on PyPI (a merge without a version bump is a safe no-op). It builds (`python -m
+  build`), uploads via `pypa/gh-action-pypi-publish` over OIDC **Trusted Publishing** (no API token),
+  and tags `vX.Y.Z` + cuts a GitHub release. So a release is just: bump `pyproject.toml` version,
+  merge to `main`. Requires the one-time PyPI trusted-publisher config (project `hunch-sdk`, owner
+  `PrithviSeran`, repo `hunch-mcp`, workflow `publish.yml`, environment `pypi`).
+- **Publishing order:** merge the version bump so the workflow ships PyPI, then
   `mcp-publisher login github && mcp-publisher publish`. Footguns: `mcp-publisher publish --dry-run`
   actually PUBLISHES in the current CLI, and re-publishing the same version 400s ("duplicate
   version"), so a registry update needs a real version bump.


### PR DESCRIPTION
Adds `.github/workflows/publish.yml` — a PyPI auto-publish hook.

## What it does
On merge to `main` touching `src/hunch/**`, `pyproject.toml`, or `README.md`:
1. Reads the version from `pyproject.toml` and checks PyPI.
2. If the version is **new** → builds (`python -m build`) and publishes via `pypa/gh-action-pypi-publish` over OIDC **Trusted Publishing** (no API token), then tags `vX.Y.Z` and cuts a GitHub release.
3. If the version **already exists** → clean no-op (so non-bump merges don't fail).

## Release flow after this
Bump `version` in `pyproject.toml` → merge to `main`. PyPI ships itself. (`server.json` + Homebrew formula still bumped manually.)

## Setup
PyPI trusted publisher already configured (owner `PrithviSeran`, repo `hunch-mcp`, workflow `publish.yml`, env `pypi`).

Also updates AGENTS.md release notes to describe the automation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)