### PR TITLE
fix(codex): stream turn events live instead of after completion

### DIFF
--- a/src/hunch/backends/codex.py
+++ b/src/hunch/backends/codex.py
@@ -22,8 +22,13 @@ Auth is a `codex login` (ChatGPT/Codex subscription) session — set it up with
 hunch.provider("codex").login() or `codex login`. No API-key path is exposed.
 
 The Codex Python SDK (`openai-codex`, beta) is an optional dependency, imported
-lazily. The SDK touch-points are `_open_thread()` and `_run_turn()`; everything else
-(config, playbook, result translation) is plain Python and unit-tested with fakes.
+lazily. The SDK touch-points are `_open_thread()` and `_start_turn()`; everything else
+(config, playbook, notification routing) is plain Python and unit-tested with fakes.
+
+Streaming: we drive the turn with the SDK's `thread.turn(input)` (a streaming handle)
+rather than the blocking `thread.run(input)`, and route each notification to on_event
+the moment it arrives — so tool calls and messages surface live, mid-turn, instead of
+all at once when the turn ends. `_consume()` is the pure router (fakeable in tests).
 """
 import json
 import os
@@ -56,6 +61,7 @@ class CodexBackend(Backend):
         super().__init__(hunch, auth=auth, app_id=app_id, can_use_tool=can_use_tool)
         self._thread = None            # the live Codex thread (continuation across run())
         self._codex = None             # the Codex client
+        self._handle = None            # the in-flight TurnHandle, for interrupt()
 
     # ── availability ────────────────────────────────────────────────────────────
     @classmethod
@@ -115,7 +121,11 @@ class CodexBackend(Backend):
         os.makedirs(d, exist_ok=True)
         return d
 
-    # ── result translation: TurnResult.items -> Hunch's on_event contract ────────
+    # ── item translation: a ThreadItem's lifecycle -> Hunch's on_event contract ──
+    # A ThreadItem surfaces twice — on `item/started` (the call is now underway) and on
+    # `item/completed` (it finished, results attached). We emit the CALL at started so a
+    # tool/command shows the instant it begins, and the RESULT/text at completed. Emitting
+    # only on completion would make a slow tool look hung until it returned.
     @staticmethod
     def _result_text(result):
         """Pull readable text out of a Codex McpToolCallResult (its .content is a list of
@@ -129,21 +139,32 @@ class CodexBackend(Backend):
                 return joined
         return str(result)
 
-    @classmethod
-    def _emit_item(cls, item, emit):
-        """Map one ThreadItem (a pydantic RootModel; real variant at .root) onto
-        emit(kind, data). Returns the item's agent text if it is a message, else ''."""
+    @staticmethod
+    def _emit_call(item, emit):
+        """On item/started: surface a tool or shell call the moment it begins (name + input).
+        Agent messages carry no text yet, so they're emitted on completion, not here."""
         root = getattr(item, "root", item)
         itype = getattr(root, "type", "") or ""
         if itype == "mcpToolCall":
             emit("tool", {"name": getattr(root, "tool", ""),
                           "input": getattr(root, "arguments", None)})
+        elif itype == "commandExecution":             # Codex ran its own shell (not a hunch tool)
+            emit("tool", {"name": "shell", "input": getattr(root, "command", "")})
+
+    @staticmethod
+    def _item_id(item):
+        return getattr(getattr(item, "root", item), "id", None)
+
+    @classmethod
+    def _emit_result(cls, item, emit):
+        """On item/completed: emit a tool's result or an agent message's text. Returns the
+        message text (so the caller can track the turn's final response), else ''."""
+        root = getattr(item, "root", item)
+        itype = getattr(root, "type", "") or ""
+        if itype == "mcpToolCall":
             result = getattr(root, "result", None)
             if result is not None:
                 emit("tool_result", cls._result_text(result)[:200])
-            return ""
-        if itype == "commandExecution":               # Codex ran its own shell (not a hunch tool)
-            emit("tool", {"name": "shell", "input": getattr(root, "command", "")})
             return ""
         if itype == "agentMessage":
             text = (getattr(root, "text", "") or "").strip()
@@ -153,13 +174,13 @@ class CodexBackend(Backend):
         return ""
 
     @staticmethod
-    def _usage_dict(result):
-        u = getattr(result, "usage", None)
-        if u is None:
+    def _usage_dict(usage):
+        """model_dump a Codex ThreadTokenUsage (or pass through a dict) to a plain dict."""
+        if usage is None:
             return {}
-        dump = getattr(u, "model_dump", None)
+        dump = getattr(usage, "model_dump", None)
         try:
-            return dump() if dump else (u if isinstance(u, dict) else {})
+            return dump() if dump else (usage if isinstance(usage, dict) else {})
         except Exception:
             return {}
 
@@ -180,10 +201,54 @@ class CodexBackend(Backend):
             self._thread = self._codex.thread_start(**kwargs)
         return self._thread
 
-    def _run_turn(self, thread, task):
-        """Run one turn to completion and return the SDK's TurnResult. Isolated so tests
-        fake it; the beta SDK's blocking run(input) returns items + final_response."""
-        return thread.run(task)
+    def _start_turn(self, thread, task):
+        """Start a STREAMING turn and return its notification iterator — the one live SDK
+        touch-point (override in tests). `thread.turn(input)` returns a TurnHandle whose
+        `.stream()` yields Notification(method, payload) objects until 'turn/completed';
+        `.interrupt()` cancels it. We stash the handle so interrupt() can reach it, and hand
+        back the raw stream for `_consume` to route. (The blocking `thread.run()` we replaced
+        buffered every item and only returned once the whole turn was done — that was the
+        no-streaming bug.)"""
+        handle = thread.turn(task)
+        self._handle = handle
+        return handle.stream()
+
+    def _consume(self, notifications, emit):
+        """Route a Codex turn's notification stream to emit(...) LIVE and return
+        (final_text, error, usage_dict, item_count). Pure over the notification objects
+        (each has `.method` and `.payload`), so tests drive it with fakes — no SDK needed.
+
+          item/started   -> emit the tool/command call (see _emit_call)
+          item/completed -> emit the tool result / message text (see _emit_result)
+          tokenUsage      -> capture usage
+          turn/completed -> capture the turn's terminal error (None on success)
+        """
+        final, error, usage, items = "", None, {}, 0
+        called = set()                                  # item ids whose call we've emitted
+        for note in notifications:
+            method = getattr(note, "method", "") or ""
+            payload = getattr(note, "payload", None)
+            item = getattr(payload, "item", None)
+            if method == "item/started":
+                if item is not None:
+                    called.add(self._item_id(item))
+                    self._emit_call(item, emit)
+            elif method == "item/completed":
+                if item is not None:
+                    items += 1
+                    # Defensive: if we never saw this item's 'started' (the stream should
+                    # always deliver it first), emit the call now so a tool is never shown
+                    # LESS than the old buffered path did — worst case it lands at completion.
+                    if self._item_id(item) not in called:
+                        self._emit_call(item, emit)
+                    text = self._emit_result(item, emit)
+                    if text:
+                        final = text
+            elif getattr(payload, "token_usage", None) is not None:
+                usage = self._usage_dict(payload.token_usage)
+            elif getattr(payload, "turn", None) is not None:   # turn/completed
+                error = getattr(payload.turn, "error", None)
+        return final, error, usage, items
 
     # ── run ──────────────────────────────────────────────────────────────────────
     def run(self, task, model=None, max_turns=40, on_event=None,
@@ -202,35 +267,40 @@ class CodexBackend(Backend):
 
         try:
             thread = self._open_thread(model, cwd)
-            result = self._run_turn(thread, task)
+            # Route the live notification stream to on_event as it arrives (no buffering).
+            final, err, usage, items = self._consume(self._start_turn(thread, task), emit)
         except Exception as e:  # noqa: BLE001 — surface transport/SDK failures as an error result
             msg = f"codex run failed: {e}"
             if any(w in str(e).lower() for w in ("login", "auth", "unauthor", "credential", "401")):
                 msg += " — authenticate first: hunch.provider('codex').login() (or `codex login`)"
             emit("error", msg)
             return _result("", "error", True, {}, 0)
+        finally:
+            self._handle = None
 
-        final = ""
-        items = getattr(result, "items", None) or []
-        for item in items:
-            text = self._emit_item(item, emit)
-            if text:
-                final = text
-        final = final or (getattr(result, "final_response", "") or "")
-        err = getattr(result, "error", None)
         aborted = err is not None
-        usage = self._usage_dict(result)
         if aborted:
             emit("error", str(err))
         else:
             emit("done", final)
-        return _result(final, "error" if aborted else "end_turn", aborted, usage, len(items))
+        return _result(final, "error" if aborted else "end_turn", aborted, usage, items)
+
+    def interrupt(self):
+        """Cancel the in-flight turn (called from another thread, e.g. a Stop button). The
+        stream in run() then ends and we return whatever completed so far."""
+        handle = self._handle
+        if handle is not None:
+            try:
+                handle.interrupt()
+            except Exception:
+                pass
 
     def reset(self):
         self._thread = None            # drop the conversation; next run() starts a fresh thread
 
     def close(self):
         self._thread = None
+        self._handle = None
         codex, self._codex = self._codex, None
         if codex is not None:
             closer = getattr(codex, "close", None)

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -105,29 +105,45 @@ def test_codex_working_dir_is_private(monkeypatch, tmp_path):
     assert os.path.isdir(d) and str(tmp_path) in d
 
 
-# ── codex result translation (TurnResult.items -> on_event) ───────────────────────
+# ── codex item translation (ThreadItem lifecycle -> on_event) ─────────────────────
 def _item(**kw):
     return types.SimpleNamespace(root=types.SimpleNamespace(**kw))
 
 
-def test_codex_emit_item():
+def _note(method, **payload):
+    """A fake Codex Notification: `.method` + `.payload` (a namespace of payload fields)."""
+    return types.SimpleNamespace(method=method, payload=types.SimpleNamespace(**payload))
+
+
+def _usage(**kw):
+    return types.SimpleNamespace(model_dump=lambda: dict(kw))
+
+
+def test_codex_emit_call_surfaces_call_at_start():
+    # item/started: the tool/command call is shown immediately; no result yet.
     events = []
     emit = lambda k, d: events.append((k, d))
-    assert CodexBackend._emit_item(_item(type="mcpToolCall", tool="snapshot",
-                                         arguments={"app": "Mail"}, result="ok"), emit) == ""
-    assert ("tool", {"name": "snapshot", "input": {"app": "Mail"}}) in events
-    assert ("tool_result", "ok") in events
+    CodexBackend._emit_call(_item(type="mcpToolCall", tool="snapshot",
+                                  arguments={"app": "Mail"}, result=None), emit)
+    assert events == [("tool", {"name": "snapshot", "input": {"app": "Mail"}})]
     events.clear()
-    assert CodexBackend._emit_item(_item(type="agentMessage", text="done"), emit) == "done"
+    CodexBackend._emit_call(_item(type="commandExecution", command="ls -la"), emit)
+    assert events == [("tool", {"name": "shell", "input": "ls -la"})]
+    events.clear()
+    CodexBackend._emit_call(_item(type="agentMessage", text=""), emit)   # messages: nothing at start
+    assert events == []
+
+
+def test_codex_emit_result_surfaces_result_and_text():
+    # item/completed: a tool's result, or a message's text (returned so run() tracks final).
+    events = []
+    emit = lambda k, d: events.append((k, d))
+    assert CodexBackend._emit_result(_item(type="mcpToolCall", tool="snapshot",
+                                           arguments={}, result="ok"), emit) == ""
+    assert events == [("tool_result", "ok")]
+    events.clear()
+    assert CodexBackend._emit_result(_item(type="agentMessage", text="done"), emit) == "done"
     assert events == [("text", "done")]
-
-
-class _FakeTurn:
-    def __init__(self, items, final_response="", error=None, usage=None):
-        self.items = items
-        self.final_response = final_response
-        self.error = error
-        self.usage = usage
 
 
 def _prep_codex(monkeypatch, tmp_path):
@@ -135,29 +151,91 @@ def _prep_codex(monkeypatch, tmp_path):
     monkeypatch.setenv("CODEX_HOME", str(tmp_path))
 
 
-def test_codex_run_streams_and_returns_result(monkeypatch, tmp_path):
+def test_codex_run_streams_live_mid_turn(monkeypatch, tmp_path):
+    """The turn's events must reach on_event AS the stream is consumed — not buffered until
+    the end. We assert the tool call is already emitted the instant its 'started' notification
+    is yielded, before the turn completes."""
     _prep_codex(monkeypatch, tmp_path)
     b = CodexBackend(_FakeHunch())
     monkeypatch.setattr(b, "_open_thread", lambda model, cwd: "THREAD")
-    turn = _FakeTurn(items=[_item(type="mcpToolCall", tool="act", arguments={}, result=None),
-                            _item(type="agentMessage", text="sent it")],
-                     final_response="sent it")
-    monkeypatch.setattr(b, "_run_turn", lambda thread, task: turn)
     events = []
-    r = b.run("send it", on_event=lambda k, d: events.append(k))
+    emit = lambda k, d: events.append((k, d))
+
+    def fake_stream(thread, task):
+        yield _note("item/started", item=_item(type="mcpToolCall", tool="act", arguments={"x": 1}))
+        # Proof of LIVE delivery: the call is on the wire before we yield anything further.
+        assert ("tool", {"name": "act", "input": {"x": 1}}) in events
+        yield _note("item/completed",
+                    item=_item(type="mcpToolCall", tool="act", arguments={"x": 1}, result="ok"))
+        yield _note("item/started", item=_item(type="agentMessage", text=""))
+        yield _note("item/completed", item=_item(type="agentMessage", text="sent it"))
+        yield _note("thread/tokenUsage/updated", token_usage=_usage(total=5))
+        yield _note("turn/completed", turn=types.SimpleNamespace(error=None))
+
+    monkeypatch.setattr(b, "_start_turn", fake_stream)
+    r = b.run("send it", on_event=emit)
+    assert [k for k, _ in events] == ["tool", "tool_result", "text", "done"]
     assert r.text == "sent it" and r.aborted is False and r.stop_reason == "end_turn"
-    assert events == ["tool", "text", "done"]
+    assert r.usage == {"total": 5} and r.turns == 2   # two completed items
 
 
-def test_codex_run_error_field(monkeypatch, tmp_path):
+def test_codex_consume_falls_back_to_call_at_completion(monkeypatch, tmp_path):
+    """If 'started' is ever missing for a tool, its call is still emitted at completion — the
+    tool is never shown less than the old buffered path did (Swift renders 'tool', not result)."""
     _prep_codex(monkeypatch, tmp_path)
     b = CodexBackend(_FakeHunch())
     monkeypatch.setattr(b, "_open_thread", lambda model, cwd: "THREAD")
-    monkeypatch.setattr(b, "_run_turn", lambda t, task: _FakeTurn(items=[], error="rate limited"))
+    monkeypatch.setattr(b, "_start_turn", lambda thread, task: iter([
+        # note: NO item/started for this tool
+        _note("item/completed", item=_item(type="mcpToolCall", id="i9", tool="act",
+                                           arguments={"x": 1}, result="ok")),
+        _note("turn/completed", turn=types.SimpleNamespace(error=None)),
+    ]))
+    events = []
+    b.run("go", on_event=lambda k, d: events.append((k, d)))
+    assert events == [("tool", {"name": "act", "input": {"x": 1}}),
+                      ("tool_result", "ok"), ("done", "")]
+
+
+def test_codex_consume_no_double_call_when_started_present(monkeypatch, tmp_path):
+    """When 'started' IS delivered, the call is emitted exactly once (not again at completion)."""
+    _prep_codex(monkeypatch, tmp_path)
+    b = CodexBackend(_FakeHunch())
+    monkeypatch.setattr(b, "_open_thread", lambda model, cwd: "THREAD")
+    monkeypatch.setattr(b, "_start_turn", lambda thread, task: iter([
+        _note("item/started", item=_item(type="mcpToolCall", id="i9", tool="act", arguments={"x": 1})),
+        _note("item/completed", item=_item(type="mcpToolCall", id="i9", tool="act",
+                                           arguments={"x": 1}, result="ok")),
+        _note("turn/completed", turn=types.SimpleNamespace(error=None)),
+    ]))
+    events = []
+    b.run("go", on_event=lambda k, d: events.append(k))
+    assert events == ["tool", "tool_result", "done"]   # exactly one 'tool'
+
+
+def test_codex_run_error_from_turn_completed(monkeypatch, tmp_path):
+    _prep_codex(monkeypatch, tmp_path)
+    b = CodexBackend(_FakeHunch())
+    monkeypatch.setattr(b, "_open_thread", lambda model, cwd: "THREAD")
+    monkeypatch.setattr(b, "_start_turn",
+                        lambda thread, task: iter([_note("turn/completed",
+                                                         turn=types.SimpleNamespace(error="rate limited"))]))
     events = []
     r = b.run("x", on_event=lambda k, d: events.append((k, d)))
     assert r.aborted is True and r.stop_reason == "error"
     assert ("error", "rate limited") in events
+
+
+def test_codex_interrupt_cancels_the_handle(monkeypatch, tmp_path):
+    _prep_codex(monkeypatch, tmp_path)
+    b = CodexBackend(_FakeHunch())
+    calls = {"n": 0}
+    b._handle = types.SimpleNamespace(interrupt=lambda: calls.__setitem__("n", calls["n"] + 1))
+    b.interrupt()
+    assert calls["n"] == 1
+    b._handle = None
+    b.interrupt()   # no live turn -> no-op, no crash
+    assert calls["n"] == 1
 
 
 # ── codex auth surface (via the provider), faking the openai_codex SDK ─────────────
@@ -257,17 +335,28 @@ def test_hunch_login_dispatches_to_provider(monkeypatch):
 def test_sdk_shape_matches_backend_assumptions():
     oc = pytest.importorskip("openai_codex")
     import inspect
-    import dataclasses
     params = inspect.signature(oc.Codex.thread_start).parameters
     for p in ("cwd", "developer_instructions", "config", "model", "sandbox"):
         assert p in params, f"thread_start lost {p!r}"
     assert hasattr(oc.Sandbox, "workspace_write")
-    turn_fields = {f.name for f in dataclasses.fields(oc.TurnResult)}
-    for f in ("items", "final_response", "error", "usage"):
-        assert f in turn_fields
+    # streaming turn surface we now drive (thread.turn -> TurnHandle.stream/.interrupt)
+    assert hasattr(oc.Thread, "turn")
+    for m in ("stream", "interrupt"):
+        assert hasattr(oc.TurnHandle, m), f"TurnHandle lost {m!r}"
     # auth methods the provider relies on
     for m in ("login_chatgpt", "login_chatgpt_device_code", "logout", "account"):
         assert hasattr(oc.Codex, m)
+
+
+def test_sdk_streaming_notification_payloads_match():
+    """The notification payload fields _consume reads: item on started/completed,
+    token_usage on the usage notification, turn (with .error) on turn/completed."""
+    pytest.importorskip("openai_codex")
+    from openai_codex import models as m
+    assert "item" in m.ItemStartedNotification.model_fields
+    assert "item" in m.ItemCompletedNotification.model_fields
+    assert "token_usage" in m.ThreadTokenUsageUpdatedNotification.model_fields
+    assert "turn" in m.TurnCompletedNotification.model_fields
 
 
 def test_sdk_accepts_our_config_overrides():
@@ -283,3 +372,58 @@ def test_sdk_item_variant_fields_match():
     assert "tool" in mcp and "arguments" in mcp and "result" in mcp
     assert typing.get_args(mcp["type"].annotation) == ("mcpToolCall",)
     assert typing.get_args(v.AgentMessageThreadItem.model_fields["type"].annotation) == ("agentMessage",)
+
+
+def test_consume_routes_real_sdk_notifications():
+    """End-to-end over REAL openai-codex objects (not fakes): build the actual Notification /
+    ThreadItem / Turn pydantic models a live turn emits and run them through the real _consume,
+    proving every attribute read (.method/.payload/.item.root.type/.tool/.result/.turn.error)
+    matches the installed SDK. Complements the SimpleNamespace unit tests, which only encode
+    our assumptions about those shapes."""
+    pytest.importorskip("openai_codex")
+    from openai_codex.models import (
+        Notification, ItemStartedNotification, ItemCompletedNotification,
+        TurnCompletedNotification, ThreadTokenUsageUpdatedNotification)
+    from openai_codex.generated import v2_all as v
+
+    def mcp(status, result=None):
+        return v.McpToolCallThreadItem(id="i1", type="mcpToolCall", server="hunch", tool="act",
+                                       arguments={"x": 1}, status=status, result=result)
+
+    def bd(n):
+        return v.TokenUsageBreakdown(cached_input_tokens=0, input_tokens=n, output_tokens=n,
+                                     reasoning_output_tokens=0, total_tokens=2 * n)
+
+    ok = v.McpToolCallResult(content=[{"type": "text", "text": "ok"}])
+    stream = [
+        Notification(method="item/started", payload=ItemStartedNotification(
+            item=mcp(v.McpToolCallStatus.in_progress), startedAtMs=1, threadId="th", turnId="t1")),
+        Notification(method="item/completed", payload=ItemCompletedNotification(
+            item=mcp(v.McpToolCallStatus.completed, result=ok), completedAtMs=2,
+            threadId="th", turnId="t1")),
+        Notification(method="item/completed", payload=ItemCompletedNotification(
+            item=v.AgentMessageThreadItem(id="m1", type="agentMessage", text="sent it"),
+            completedAtMs=3, threadId="th", turnId="t1")),
+        Notification(method="thread/tokenUsage/updated", payload=ThreadTokenUsageUpdatedNotification(
+            threadId="th", turnId="t1", tokenUsage=v.ThreadTokenUsage(last=bd(5), total=bd(21)))),
+        Notification(method="turn/completed", payload=TurnCompletedNotification(
+            threadId="th", turn=v.Turn(id="t1", items=[], status=v.TurnStatus.completed))),
+    ]
+    b = CodexBackend(_FakeHunch())
+    events = []
+    final, error, usage, items = b._consume(iter(stream), lambda k, d: events.append((k, d)))
+    assert events == [
+        ("tool", {"name": "act", "input": {"x": 1}}),   # surfaced at item/started
+        ("tool_result", "ok"),                            # surfaced at item/completed
+        ("text", "sent it"),
+    ]
+    assert final == "sent it" and error is None and items == 2
+    assert usage["total"]["total_tokens"] == 42
+
+    # a failed turn surfaces its TurnError
+    _, err2, _, _ = b._consume(iter([
+        Notification(method="turn/completed", payload=TurnCompletedNotification(
+            threadId="th", turn=v.Turn(id="t1", items=[], status=v.TurnStatus.failed,
+                                       error=v.TurnError(message="boom"))))]),
+        lambda k, d: None)
+    assert getattr(err2, "message", None) == "boom"


### PR DESCRIPTION
## Problem

The `codex` backend drove each turn with the SDK's **blocking `thread.run()`**, which buffers every message and tool call and returns only once the whole turn is done. The backend then replayed all buffered items to `on_event` at the end — so the UI showed nothing until the turn finished, then dumped every event at once. Every other backend streams live; codex was the lone exception.

## Fix

Switch to the SDK's **streaming handle**: `thread.turn(input)` → `TurnHandle`, iterate `.stream()`, and route each notification to `on_event` the moment it arrives:

- **`item/started`** → emit the tool/command call (visible the instant it begins — matters for slow Hunch tools like `web`/`act`)
- **`item/completed`** → emit the tool result / message text
- **`turn/completed`** → capture the terminal error

Also wires up a real `interrupt()` via the handle (was a no-op).

Pure end-to-end streaming change — the `on_event(kind, data)` contract is unchanged, so the app sidecar and Swift UI stream live with **no app changes**.

### Defensive fallback
Swift renders the `tool` event (emitted at `item/started`), not `tool_result`. If the live stream ever delivered `item/completed` without a preceding `item/started`, the call is still emitted at completion — so a tool is **never shown less than the old buffered path did**. Worst case degrades to old-ish timing, never a crash or blank.

## Verification (no live Codex turn / quota needed)

- **142 tests pass**, with the codex tests running against the **real openai-codex 0.144.4** (no skips).
- New **real-object integration test** builds the actual `Notification` / `ThreadItem` / `Turn` pydantic models a live turn emits and runs them through the real `_consume` — proving every attribute read matches the installed SDK (the layer a fake can't cover).
- New **live-emission test** proves events reach `on_event` mid-stream, not buffered to the end.
- New **fallback tests** cover the missing-`started` path and the no-double-emit path.
- Real-SDK shape guards updated to pin the streaming surface (`thread.turn` / `TurnHandle.stream` / `.interrupt` / notification payload fields).

The only thing not covered offline is the live server's exact notification timing — governed by the Codex protocol this is built against, and made safe by the defensive fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)