### PR TITLE
chore: bump 0.6.1 to release the wrong-window fixes (+ fix server.json drift)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hunch-sdk"
-version = "0.6.0"
+version = "0.6.1"
 description = "Drive your Mac focus-free over MCP: OS APIs, AppleScript, CDP, and Accessibility."
 readme = "README.md"
 license = "Apache-2.0"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.PrithviSeran/hunch",
   "description": "Focus-free macOS control for AI agents: drive your real Mac apps in the background, no stolen focus.",
-  "version": "0.5.5",
+  "version": "0.6.1",
   "repository": {
     "url": "https://github.com/PrithviSeran/hunch-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "pypi",
       "identifier": "hunch-sdk",
-      "version": "0.5.5",
+      "version": "0.6.1",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Follow-up to #12. **The fixes it merged are on `main` but not released.**

## What happened

`publish.yml` only uploads when `pyproject.toml`'s version is one PyPI doesn't already have. #12 merged at 0.6.0 — a version already on PyPI — so the run on the merge commit did exactly what it's designed to do:

```
Should we publish?: success
Build & publish:    skipped
```

([run 31031060102](https://github.com/PrithviSeran/hunch-mcp/actions/runs/31031060102))

So the wrong-window fixes are sitting on `main`, unpublished. A macOS app rebuild today would pip-install 0.6.0 and get none of them.

## What this does

- `pyproject.toml` 0.6.0 → **0.6.1** (patch: bug fixes, no API change). Merging this publishes 0.6.1, tags `v0.6.1`, and cuts a GitHub release automatically.
- `server.json` **0.5.5 → 0.6.1** (both the top-level and the package entry). This is pre-existing drift: the 0.6.0 release bumped the file the workflow reads and missed the registry manifest it doesn't, so nothing caught it. All three version sites now agree.

## Still manual, not in this PR

- **`homebrew-hunch`** is unrelatedly stale — the formula still points at the `v0.1.2` GitHub tarball, ~5 releases behind, and `bump-0.5.5.sh`'s rewrite was never applied. Separate repo, separate fix.
- **The macOS app in `~/hunch` needs no code change** — `app/mac/package.sh` pip-installs `hunch-sdk[...]>=0.6.0` from PyPI at build time and `app/hunch_agent.py` just `import hunch`. Rebuild it once 0.6.1 publishes and it picks the fixes up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)