### PR TITLE
fix(ax): guard the tree walk against unbounded recursion

### DIFF
--- a/src/hunch/local_mac.py
+++ b/src/hunch/local_mac.py
@@ -286,6 +286,14 @@ _MAX_NODES = 3000          # default node budget for a FULL-window walk
 _MAX_DEPTH = 18            # default depth for a FULL-window walk
 _SCOPED_MAX_NODES = 10000  # defaults for scoped (ref=) subtree walks and find()
 _SCOPED_MAX_DEPTH = 100    # "full depth" while still guarding Python recursion
+# HARD recursion guard, independent of max_depth. max_depth counts only EMITTED
+# nodes (scaffolding is walked "for free" so the visible tree isn't dominated by
+# wrapper groups), so a long enough chain of uninteresting containers recurses
+# without ever advancing `depth`. The node budget is then the only backstop, and
+# with _MAX_NODES=3000 > CPython's 1000-frame limit it loses the race: a real
+# System Settings pane raised RecursionError mid-walk and killed snapshot()
+# outright (2026-08-06). Truncate here instead — a capped tree beats a crash.
+_MAX_RECURSION = 300
 _NODES_CEILING = 50000     # hard safety ceiling everywhere
 _MAX_CHILDREN = 200        # per-node sibling cap for a FULL-window walk (marked + recoverable)
 _SCOPED_MAX_CHILDREN = 1000  # raised cap for scoped (ref=) walks and find(): page a big list in
@@ -693,8 +701,13 @@ class MacSession:
                       "app": app_name, "matches": len(results), "searched": searched[0]}
 
     def _walk(self, el, depth, parent_key, lines, compact, max_depth, budget, sib=None,
-              root_key=None, max_children=_MAX_CHILDREN):
+              root_key=None, max_children=_MAX_CHILDREN, raw_depth=0):
         if budget["left"] <= 0:
+            budget["hit"] = True
+            return
+        if raw_depth >= _MAX_RECURSION:
+            # Every frame counts here, emitted or not — see _MAX_RECURSION.
+            lines.append("  " * depth + "…(nesting limit reached — subtree not walked)")
             budget["hit"] = True
             return
         budget["left"] -= 1
@@ -739,7 +752,7 @@ class MacSession:
         child_sib = {}
         for child in list(children)[:max_children]:
             self._walk(child, depth_out, key, lines, compact, max_depth, budget, child_sib,
-                       max_children=max_children)
+                       max_children=max_children, raw_depth=raw_depth + 1)
         if len(children) > max_children:
             # Recoverable, like the depth/node caps: give the truncated container a
             # ref (mint one if it wasn't emitted — a list container is usually

--- a/tests/test_walk.py
+++ b/tests/test_walk.py
@@ -197,6 +197,39 @@ def test_cap_semantics():
     assert _cap_nodes(999999, 3000) == 50000
 
 
+def test_deep_scaffolding_does_not_blow_the_stack():
+    """A long chain of UNINTERESTING containers must truncate, not RecursionError.
+
+    max_depth only advances on EMITTED nodes, so scaffolding is walked for free
+    — which means a deep enough chain recurses with `depth` pinned at 0 and the
+    node budget (3000) as the only backstop, well past CPython's 1000-frame
+    limit. A real System Settings pane hit exactly this and killed snapshot()
+    (2026-08-06). _MAX_RECURSION must stop it first.
+    """
+    root = FakeEl("AXGroup")          # AXGroup with no title/value: never emitted
+    tip = root
+    for _ in range(1500):
+        child = FakeEl("AXGroup")
+        tip.children.append(child)
+        tip = child
+    tip.children.append(FakeEl("AXButton", title="Deep"))
+
+    with _patched(Fetcher()):
+        out = _snapshot_tree(_session(), root)   # must not raise
+    assert "nesting limit reached" in out
+    # and the guard must fire well below CPython's limit
+    assert local_mac._MAX_RECURSION < 1000
+
+
+def test_shallow_tree_unaffected_by_recursion_guard():
+    """The guard must not perturb ordinary trees."""
+    root = FakeEl("AXWindow", title="W", children=[
+        FakeEl("AXGroup", children=[FakeEl("AXButton", title="OK")])])
+    with _patched(Fetcher()):
+        out = _snapshot_tree(_session(), root)
+    assert "OK" in out and "nesting limit" not in out
+
+
 def test_cdp_truncation_marker():
     from hunch.cdp import CDPSession
     s = CDPSession.__new__(CDPSession)


### PR DESCRIPTION
## The bug

`snapshot()` can die with `RecursionError` instead of returning a tree.

`_walk` only advances `depth` when a node is **emitted** — scaffolding is walked "for free" so the visible tree isn't dominated by wrapper groups. A long enough chain of uninteresting containers therefore recurses with `depth` pinned, leaving the node budget as the only backstop. With `_MAX_NODES=3000` against CPython's 1000-frame limit, the budget loses the race.

This is not theoretical: a real **System Settings** pane blew the stack mid-walk and killed the snapshot outright (987 frames deep). The existing `_SCOPED_MAX_DEPTH` comment ("while still guarding Python recursion") shows the risk was anticipated, but the guard was incomplete.

## The fix

`_MAX_RECURSION = 300`, counted on **every** frame regardless of emission. On hit, emit a truncation marker and set `budget["hit"]` — the same recoverable-degradation contract as the depth/node/children caps. A capped tree beats a crash.

## Tests

Two added to `tests/test_walk.py`:
- 1500-deep chain of nameless `AXGroup`s must truncate, not raise
- ordinary shallow trees are unaffected by the guard

`160 passed, 1 failed` — the failure is `test_screen_approval_dedupe`, pre-existing on main and unrelated.

## Provenance

Found while crawling System Settings to build the AX state-map dataset; the crawler died on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)