### PR TITLE
backends: add 'ollama' — local model (qwen3.5:9b) drives the agent loop

### DIFF
--- a/src/hunch/backends/__init__.py
+++ b/src/hunch/backends/__init__.py
@@ -14,7 +14,7 @@ from .base import Backend
 __all__ = ["Backend", "NAMES", "get", "available", "meta", "provider_names"]
 
 # Ordered: 'auto' resolution prefers earlier entries when several are usable.
-NAMES = ("api", "subscription", "codex")
+NAMES = ("api", "subscription", "codex", "ollama")
 
 
 def get(name):
@@ -29,6 +29,9 @@ def get(name):
     if name == "codex":
         from .codex import CodexBackend
         return CodexBackend
+    if name == "ollama":
+        from .ollama import OllamaBackend
+        return OllamaBackend
     from ..errors import HunchError
     raise HunchError(f"unknown backend {name!r} — use "
                      + ", ".join(repr(n) for n in NAMES) + ", or 'auto'")

--- a/src/hunch/backends/ollama.py
+++ b/src/hunch/backends/ollama.py
@@ -1,0 +1,231 @@
+"""backends/ollama.py — the 'ollama' backend: a LOCAL model drives this Mac.
+
+Runs the same agent loop as the 'api' backend — HUNCH_PLAYBOOK as the system
+prompt, AGENT_TOOLS as native tool schemas, tools executed in-process against the
+caller's live Hunch instance via _dispatch_core — but the model is served by a
+local Ollama daemon (http://127.0.0.1:11434), so there is no account, no API key,
+and no per-token cost. Stdlib-only: the transport is urllib against Ollama's
+/api/chat, no optional package to install.
+
+Knobs (env):
+  HUNCH_OLLAMA_MODEL    model tag (default 'qwen3.5:9b')
+  HUNCH_OLLAMA_HOST     server base URL (default 'http://127.0.0.1:11434')
+  HUNCH_OLLAMA_NUM_CTX  context window (default 32768 — Ollama's own default can
+                        be far smaller than the model supports, which would
+                        silently truncate the playbook + AX snapshots)
+  HUNCH_OLLAMA_STRICT   '1' disables the fallback tool-call parser (see below)
+
+Two measured facts about small local models shape this file (probe 2026-08-07,
+qwen3.5:9b on the real playbook + a real Settings snapshot):
+
+  • Thinking is ON by default and burned ~900 decode tokens per turn — pure
+    latency in an agent loop. We send "think": false on every request.
+  • With the playbook as system prompt the model sometimes IMITATES the playbook's
+    prose tool descriptions instead of using the native tool channel — it prints a
+    well-formed JSON call inside a markdown fence. The loop recovers those with a
+    conservative fallback parser and COUNTS them (usage['fallback_tool_calls']),
+    so a bench run reports how often the native channel was missed instead of
+    scoring a formatting miss as a task failure. HUNCH_OLLAMA_STRICT=1 turns the
+    fallback off to measure the native channel alone.
+"""
+import json
+import os
+import re
+import urllib.error
+import urllib.request
+
+from .base import Backend
+from ..errors import HunchError
+
+__all__ = ["OllamaBackend"]
+
+DEFAULT_MODEL = "qwen3.5:9b"
+DEFAULT_HOST = "http://127.0.0.1:11434"
+DEFAULT_NUM_CTX = 32768
+
+# One fenced or bare JSON object candidate in assistant prose (non-greedy; the
+# parser json.loads-validates every candidate, so a loose match is harmless).
+_JSON_CANDIDATE = re.compile(r"```(?:json)?\s*(\{.*?\})\s*```|(\{[^`]*\})", re.DOTALL)
+
+
+class OllamaBackend(Backend):
+    """A local Ollama-served model as the agent loop, tools in-process."""
+
+    name = "ollama"
+    provider = "ollama"
+    extra = ""                      # stdlib-only; nothing extra to install
+    default_model = os.environ.get("HUNCH_OLLAMA_MODEL", DEFAULT_MODEL)
+
+    def __init__(self, hunch, *, auth=None, app_id=None, can_use_tool=None):
+        super().__init__(hunch, auth=auth, app_id=app_id, can_use_tool=can_use_tool)
+        self.messages = []          # conversation state; run() continues, reset() clears
+        self._abort = False         # between-turns cancel flag (see interrupt())
+
+    # ── availability ────────────────────────────────────────────────────────────
+    @classmethod
+    def deps_installed(cls):
+        return True                 # urllib is the whole transport
+
+    @classmethod
+    def available(cls, app_id=None):
+        """True when the local Ollama server answers. A network probe, kept short so
+        `hunch doctor` and 'auto' resolution stay snappy when nothing is running."""
+        try:
+            with urllib.request.urlopen(cls._host() + "/api/tags", timeout=1.5):
+                return True
+        except Exception:
+            return False
+
+    @staticmethod
+    def _host():
+        return os.environ.get("HUNCH_OLLAMA_HOST", DEFAULT_HOST).rstrip("/")
+
+    # ── request plumbing ─────────────────────────────────────────────────────────
+    @staticmethod
+    def _tools():
+        """AGENT_TOOLS in Ollama's (OpenAI-style) function-tool shape — same names and
+        schemas, so every HUNCH_PLAYBOOK reference resolves for this model too."""
+        from ..agent import AGENT_TOOLS
+        return [{"type": "function",
+                 "function": {"name": t["name"], "description": t["description"],
+                              "parameters": t["input_schema"]}}
+                for t in AGENT_TOOLS]
+
+    def _chat(self, body):
+        """POST one /api/chat turn and return the decoded response — the single live
+        transport touch-point (override in tests). Timeout is generous: a cold model
+        load plus a long prefill on Apple Silicon can take minutes."""
+        req = urllib.request.Request(
+            self._host() + "/api/chat", data=json.dumps(body).encode(),
+            headers={"Content-Type": "application/json"})
+        try:
+            with urllib.request.urlopen(req, timeout=600) as r:
+                return json.loads(r.read())
+        except urllib.error.HTTPError as e:
+            detail = ""
+            try:
+                detail = json.loads(e.read()).get("error", "")
+            except Exception:
+                pass
+            if "not found" in detail.lower():
+                raise HunchError(f"Ollama has no model {body['model']!r} — pull it with: "
+                                 f"ollama pull {body['model']}") from e
+            raise HunchError(f"ollama request failed: {detail or e}") from e
+        except urllib.error.URLError as e:
+            raise HunchError(f"no Ollama server at {self._host()} — start it with "
+                             "`ollama serve` (or install: brew install ollama)") from e
+
+    def _body(self, model, system):
+        return {"model": model, "stream": False, "think": False,
+                "tools": self._tools(),
+                "options": {"num_ctx": int(os.environ.get("HUNCH_OLLAMA_NUM_CTX",
+                                                          DEFAULT_NUM_CTX))},
+                "messages": [{"role": "system", "content": system}] + self.messages}
+
+    # ── tool-call recovery (the playbook-imitation failure mode) ─────────────────
+    @staticmethod
+    def _fallback_calls(text):
+        """Recover tool calls a model wrote as prose/markdown JSON instead of using the
+        native channel. Conservative: a candidate must json-parse to an object naming a
+        real AGENT_TOOLS tool with dict arguments. Returns [{'name', 'arguments'}, ...]."""
+        from ..agent import AGENT_TOOLS
+        known = {t["name"] for t in AGENT_TOOLS}
+        calls = []
+        for m in _JSON_CANDIDATE.finditer(text or ""):
+            try:
+                obj = json.loads(m.group(1) or m.group(2))
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if not isinstance(obj, dict):
+                continue
+            name = obj.get("name") or obj.get("tool") or obj.get("tool_name")
+            args = obj.get("arguments") or obj.get("input") or obj.get("parameters")
+            if name in known and isinstance(args, (dict, type(None))):
+                calls.append({"name": name, "arguments": args or {}})
+        return calls
+
+    @staticmethod
+    def _call_args(call):
+        """A native tool_call's arguments as a dict (Ollama sends a parsed object, but
+        some models/versions return a JSON string)."""
+        args = (call.get("function") or {}).get("arguments")
+        if isinstance(args, str):
+            try:
+                args = json.loads(args)
+            except json.JSONDecodeError:
+                args = {}
+        return args if isinstance(args, dict) else {}
+
+    def _run_tool(self, name, args, emit):
+        """Dispatch one call and return its role='tool' message. PNG bytes ride in
+        Ollama's images channel (base64) with a text placeholder."""
+        import base64
+        from .. import agent as _agent
+        emit("tool", {"name": name, "input": args})
+        value, is_error = _agent._dispatch_core(self._h, name, args)
+        if isinstance(value, bytes):
+            emit("tool_result", "[image]")
+            return {"role": "tool", "tool_name": name, "content": "(screenshot attached)",
+                    "images": [base64.b64encode(value).decode()]}
+        text = ("error: " if is_error and not str(value).startswith("error") else "") + str(value)
+        emit("tool_result", text[:200])
+        return {"role": "tool", "tool_name": name, "content": text}
+
+    # ── lifecycle ────────────────────────────────────────────────────────────────
+    def interrupt(self):
+        self._abort = True          # checked between turns
+
+    def reset(self):
+        self.messages = []
+
+    # ── run ──────────────────────────────────────────────────────────────────────
+    def run(self, task, model=None, max_turns=40, on_event=None,
+            system_suffix="", effort=None, max_tokens=16000):
+        from ..playbook import HUNCH_PLAYBOOK
+        from ..agent import AGENT_ADDENDUM, AgentResult
+        emit = on_event or (lambda kind, data: None)
+        model = model or self.default_model
+        system = HUNCH_PLAYBOOK + "\n" + AGENT_ADDENDUM
+        if system_suffix:
+            system += "\n" + system_suffix
+        strict = os.environ.get("HUNCH_OLLAMA_STRICT") == "1"
+
+        self.messages.append({"role": "user", "content": task})
+        usage = {"input_tokens": 0, "output_tokens": 0, "fallback_tool_calls": 0}
+        stop_reason, final_text, aborted, turn = "max_turns", "", True, 0
+        self._abort = False
+
+        for turn in range(1, max_turns + 1):
+            if self._abort:                       # interrupt() between turns
+                stop_reason, aborted = "interrupted", True
+                emit("error", "interrupted")
+                break
+            resp = self._chat(self._body(model, system))
+            usage["input_tokens"] += resp.get("prompt_eval_count") or 0
+            usage["output_tokens"] += resp.get("eval_count") or 0
+            msg = resp.get("message") or {}
+            text = (msg.get("content") or "").strip()
+            if text:
+                emit("text", text)
+            self.messages.append(msg)             # replay verbatim next turn
+
+            calls = [{"name": (c.get("function") or {}).get("name", ""),
+                      "arguments": self._call_args(c)}
+                     for c in (msg.get("tool_calls") or [])]
+            if not calls and not strict:
+                calls = self._fallback_calls(text)
+                usage["fallback_tool_calls"] += len(calls)
+            if calls:
+                # ALL results appended before the next request, mirroring ApiBackend
+                for c in calls:
+                    self.messages.append(self._run_tool(c["name"], c["arguments"], emit))
+                continue
+
+            stop_reason, final_text, aborted = "end_turn", text, False
+            emit("done", final_text)
+            break
+        else:
+            emit("error", f"aborted after max_turns={max_turns}")
+
+        return AgentResult(text=final_text, turns=turn, stop_reason=stop_reason,
+                           usage=usage, aborted=aborted)

--- a/src/hunch/backends/ollama.py
+++ b/src/hunch/backends/ollama.py
@@ -91,29 +91,36 @@ class OllamaBackend(Backend):
                               "parameters": t["input_schema"]}}
                 for t in AGENT_TOOLS]
 
-    def _chat(self, body):
+    def _chat(self, body, _attempts=3):
         """POST one /api/chat turn and return the decoded response — the single live
         transport touch-point (override in tests). Timeout is generous: a cold model
-        load plus a long prefill on Apple Silicon can take minutes."""
-        req = urllib.request.Request(
-            self._host() + "/api/chat", data=json.dumps(body).encode(),
-            headers={"Content-Type": "application/json"})
-        try:
-            with urllib.request.urlopen(req, timeout=600) as r:
-                return json.loads(r.read())
-        except urllib.error.HTTPError as e:
-            detail = ""
+        load plus a long prefill on Apple Silicon can take minutes. Transient HTTP
+        errors are retried: qwen3.5's tool-call XML template occasionally fails to
+        parse a single generation and Ollama 500s ('element <function> closed by
+        </parameter>', seen 2026-08-08) — a per-request fluke that must not kill the
+        whole episode."""
+        for attempt in range(_attempts):
+            req = urllib.request.Request(
+                self._host() + "/api/chat", data=json.dumps(body).encode(),
+                headers={"Content-Type": "application/json"})
             try:
-                detail = json.loads(e.read()).get("error", "")
-            except Exception:
-                pass
-            if "not found" in detail.lower():
-                raise HunchError(f"Ollama has no model {body['model']!r} — pull it with: "
-                                 f"ollama pull {body['model']}") from e
-            raise HunchError(f"ollama request failed: {detail or e}") from e
-        except urllib.error.URLError as e:
-            raise HunchError(f"no Ollama server at {self._host()} — start it with "
-                             "`ollama serve` (or install: brew install ollama)") from e
+                with urllib.request.urlopen(req, timeout=600) as r:
+                    return json.loads(r.read())
+            except urllib.error.HTTPError as e:
+                detail = ""
+                try:
+                    detail = json.loads(e.read()).get("error", "")
+                except Exception:
+                    pass
+                if "not found" in detail.lower():
+                    raise HunchError(f"Ollama has no model {body['model']!r} — pull it "
+                                     f"with: ollama pull {body['model']}") from e
+                if attempt < _attempts - 1:
+                    continue
+                raise HunchError(f"ollama request failed: {detail or e}") from e
+            except urllib.error.URLError as e:
+                raise HunchError(f"no Ollama server at {self._host()} — start it with "
+                                 "`ollama serve` (or install: brew install ollama)") from e
 
     def _body(self, model, system):
         return {"model": model, "stream": False, "think": False,

--- a/src/hunch/backends/ollama.py
+++ b/src/hunch/backends/ollama.py
@@ -198,8 +198,10 @@ class OllamaBackend(Backend):
         strict = os.environ.get("HUNCH_OLLAMA_STRICT") == "1"
 
         self.messages.append({"role": "user", "content": task})
-        usage = {"input_tokens": 0, "output_tokens": 0, "fallback_tool_calls": 0}
+        usage = {"input_tokens": 0, "output_tokens": 0, "fallback_tool_calls": 0,
+                 "continue_nudges": 0}
         stop_reason, final_text, aborted, turn = "max_turns", "", True, 0
+        acted = False                  # any tool call dispatched this run
         self._abort = False
 
         for turn in range(1, max_turns + 1):
@@ -223,9 +225,22 @@ class OllamaBackend(Backend):
                 calls = self._fallback_calls(text)
                 usage["fallback_tool_calls"] += len(calls)
             if calls:
+                acted = True
                 # ALL results appended before the next request, mirroring ApiBackend
                 for c in calls:
                     self.messages.append(self._run_tool(c["name"], c["arguments"], emit))
+                continue
+
+            # Announce-without-act: small local models sometimes narrate the plan and
+            # stop before any tool call (also seen when Ollama drops a generation's
+            # malformed tool-call XML, leaving only prose). Ending there scores a
+            # formatting fluke as a task failure, so push back — bounded and COUNTED
+            # (usage['continue_nudges']) to keep the measurement honest.
+            if not acted and usage["continue_nudges"] < 2:
+                usage["continue_nudges"] += 1
+                self.messages.append({"role": "user", "content":
+                                      "You have not called any tool yet. Do not describe "
+                                      "the plan — act now by calling a tool."})
                 continue
 
             stop_reason, final_text, aborted = "end_turn", text, False

--- a/src/hunch/providers.py
+++ b/src/hunch/providers.py
@@ -16,7 +16,9 @@ Standalone, without a Mac instance (e.g. a setup script):
 
 Only SUBSCRIPTION / login transports are exposed — metered API keys are intentionally
 left out for now (they add confusion and nobody drives Hunch on their own key). Each
-provider therefore maps to exactly one login-based agent backend.
+provider therefore maps to exactly one login-based agent backend. The exception is
+'ollama' (a local model): it has no account at all, so its auth surface is a
+server-reachability check rather than a sign-in.
 
 To add a vendor: subclass Provider, implement login/logout/status/make_backend, and
 register it in PROVIDERS. Nothing else in the SDK needs to learn the new name.
@@ -136,7 +138,44 @@ class CodexProvider(Provider):
         return CodexBackend.deps_installed()
 
 
-PROVIDERS = {"claude": ClaudeProvider, "codex": CodexProvider}
+class OllamaProvider(Provider):
+    """A local model served by Ollama — no account, so the auth surface degrades to a
+    server-reachability check: login() verifies the daemon answers (raising with the
+    fix when it doesn't), status() reports reachable-as-signed-in, logout() is a no-op."""
+
+    name = "ollama"
+    extra = ""                      # stdlib transport; nothing to install
+
+    def _reachable(self):
+        from .backends.ollama import OllamaBackend
+        return OllamaBackend.available()
+
+    def login(self, **kwargs):
+        from .backends.ollama import OllamaBackend
+        if not self._reachable():
+            raise HunchError(f"no Ollama server at {OllamaBackend._host()} — start it "
+                             "with `ollama serve` (or install: brew install ollama)")
+        return self.status()
+
+    def logout(self, **kwargs):
+        return None                 # nothing to sign out of
+
+    def status(self, **kwargs):
+        from .backends.ollama import OllamaBackend
+        up = self._reachable()
+        return AuthStatus("ollama", up, "local" if up else None,
+                          plan=OllamaBackend.default_model if up else None)
+
+    def make_backend(self, hunch, *, auth=None, app_id=None, can_use_tool=None):
+        from .backends.ollama import OllamaBackend
+        return OllamaBackend(hunch, app_id=app_id, can_use_tool=can_use_tool)
+
+    @classmethod
+    def deps_installed(cls):
+        return True
+
+
+PROVIDERS = {"claude": ClaudeProvider, "codex": CodexProvider, "ollama": OllamaProvider}
 
 
 def names():

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -24,7 +24,7 @@ class _FakeHunch:
 
 # ── provider registry ─────────────────────────────────────────────────────────
 def test_provider_registry():
-    assert set(PROVIDERS) == {"claude", "codex"}
+    assert set(PROVIDERS) == {"claude", "codex", "ollama"}
     assert isinstance(provider("claude"), ClaudeProvider)
     assert isinstance(provider("codex"), CodexProvider)
 

--- a/tests/test_ollama_backend.py
+++ b/tests/test_ollama_backend.py
@@ -1,0 +1,173 @@
+"""Ollama backend + provider tests — all around the one live transport touch-point
+(_chat), faked here so no Ollama server is needed. Mirrors test_codex_backend.py."""
+import json
+import urllib.error
+
+import pytest
+
+import hunch.agent as agent_mod
+from hunch.agent import AGENT_TOOLS
+from hunch.backends import NAMES, get
+from hunch.backends.ollama import OllamaBackend
+from hunch.providers import provider, PROVIDERS, OllamaProvider
+from hunch.errors import HunchError
+
+
+class _FakeHunch:
+    def __init__(self):
+        self._app_id = None
+
+
+def _backend(responses, dispatch=None, monkeypatch=None):
+    """An OllamaBackend whose _chat pops canned responses and whose tool dispatch is
+    recorded (default: every tool returns 'ok')."""
+    b = OllamaBackend(_FakeHunch())
+    b._sent = []
+    seq = list(responses)
+    b._chat = lambda body: (b._sent.append(body), seq.pop(0))[1]
+    if monkeypatch is not None:
+        calls = []
+        def fake_dispatch(mac, name, args):
+            calls.append((name, args))
+            return (dispatch or (lambda n, a: "ok"))(name, args), False
+        monkeypatch.setattr(agent_mod, "_dispatch_core", fake_dispatch)
+        b._calls = calls
+    return b
+
+
+def _msg(content="", tool_calls=None):
+    m = {"message": {"role": "assistant", "content": content}}
+    if tool_calls:
+        m["message"]["tool_calls"] = tool_calls
+    return m
+
+
+# ── registry ──────────────────────────────────────────────────────────────────
+def test_registry_and_metadata():
+    assert "ollama" in NAMES
+    assert get("ollama") is OllamaBackend
+    assert "ollama" in PROVIDERS and isinstance(provider("ollama"), OllamaProvider)
+    assert (OllamaBackend.name, OllamaBackend.provider) == ("ollama", "ollama")
+    assert OllamaBackend.deps_installed() is True          # stdlib-only
+
+
+def test_tools_are_agent_tools_in_function_shape():
+    tools = OllamaBackend._tools()
+    assert [t["function"]["name"] for t in tools] == [t["name"] for t in AGENT_TOOLS]
+    assert all(t["type"] == "function" for t in tools)
+    assert tools[0]["function"]["parameters"] == AGENT_TOOLS[0]["input_schema"]
+
+
+# ── the loop ──────────────────────────────────────────────────────────────────
+def test_run_native_tool_loop(monkeypatch):
+    b = _backend([
+        _msg(tool_calls=[{"function": {"name": "list_apps", "arguments": {}}}]),
+        _msg("done — Notes is running."),
+    ], monkeypatch=monkeypatch)
+    events = []
+    r = b.run("which apps run?", on_event=lambda k, d: events.append((k, d)))
+    assert b._calls == [("list_apps", {})]
+    assert r.text == "done — Notes is running." and not r.aborted
+    assert r.stop_reason == "end_turn" and r.turns == 2
+    assert ("tool", {"name": "list_apps", "input": {}}) in events
+    assert events[-1] == ("done", "done — Notes is running.")
+    # request shape: playbook system message, think off, explicit num_ctx, tools attached
+    body = b._sent[0]
+    assert body["think"] is False and body["options"]["num_ctx"] > 0
+    assert body["messages"][0]["role"] == "system"
+    assert "num_ctx" in body["options"] and body["tools"]
+    # tool result went back as a role='tool' message with the tool's name
+    tool_msgs = [m for m in b._sent[1]["messages"] if m.get("role") == "tool"]
+    assert tool_msgs == [{"role": "tool", "tool_name": "list_apps", "content": "ok"}]
+
+
+def test_run_parses_string_arguments(monkeypatch):
+    b = _backend([
+        _msg(tool_calls=[{"function": {"name": "snapshot",
+                                       "arguments": json.dumps({"app": "Notes"})}}]),
+        _msg("ok"),
+    ], monkeypatch=monkeypatch)
+    b.run("look at Notes")
+    assert b._calls == [("snapshot", {"app": "Notes"})]
+
+
+def test_fallback_parses_prose_tool_call(monkeypatch):
+    # The measured qwen3.5 failure mode: a well-formed call in a markdown fence
+    # instead of the native channel. It must be recovered AND counted.
+    prose = ('I will inspect the app.\n```json\n'
+             '{"name": "snapshot", "arguments": {"app": "Notes"}}\n```')
+    b = _backend([_msg(prose), _msg("finished")], monkeypatch=monkeypatch)
+    r = b.run("look at Notes")
+    assert b._calls == [("snapshot", {"app": "Notes"})]
+    assert r.usage["fallback_tool_calls"] == 1 and r.text == "finished"
+
+
+def test_fallback_ignores_non_tool_json(monkeypatch):
+    b = _backend([_msg('the config is ```json\n{"volume": 11}\n``` — done')],
+                 monkeypatch=monkeypatch)
+    r = b.run("read config")
+    assert b._calls == [] and r.stop_reason == "end_turn"
+    assert r.usage["fallback_tool_calls"] == 0
+
+
+def test_strict_disables_fallback(monkeypatch):
+    monkeypatch.setenv("HUNCH_OLLAMA_STRICT", "1")
+    prose = '```json\n{"name": "list_apps", "arguments": {}}\n```'
+    b = _backend([_msg(prose)], monkeypatch=monkeypatch)
+    r = b.run("apps?")
+    assert b._calls == [] and r.stop_reason == "end_turn"
+
+
+def test_screenshot_bytes_ride_images_channel(monkeypatch):
+    b = _backend([
+        _msg(tool_calls=[{"function": {"name": "screenshot", "arguments": {}}}]),
+        _msg("saw it"),
+    ], dispatch=lambda n, a: b"\x89PNG...", monkeypatch=monkeypatch)
+    b.run("what is on screen?")
+    tool_msg = [m for m in b._sent[1]["messages"] if m.get("role") == "tool"][0]
+    assert tool_msg["images"] and "screenshot" in tool_msg["content"]
+
+
+def test_max_turns_aborts(monkeypatch):
+    call = _msg(tool_calls=[{"function": {"name": "list_apps", "arguments": {}}}])
+    b = _backend([call, call], monkeypatch=monkeypatch)
+    r = b.run("loop forever", max_turns=2)
+    assert r.aborted and r.stop_reason == "max_turns" and r.turns == 2
+
+
+def test_usage_accumulates_and_reset_clears():
+    b = _backend([{**_msg("hi"), "prompt_eval_count": 100, "eval_count": 7}])
+    r = b.run("hello")
+    assert (r.usage["input_tokens"], r.usage["output_tokens"]) == (100, 7)
+    assert b.messages          # conversation kept for continuation
+    b.reset()
+    assert b.messages == []
+
+
+def test_no_server_raises_friendly_hint(monkeypatch):
+    b = OllamaBackend(_FakeHunch())
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *a, **k: (_ for _ in ()).throw(urllib.error.URLError("refused")))
+    with pytest.raises(HunchError) as e:
+        b.run("hi")
+    assert "ollama serve" in str(e.value)
+    assert OllamaBackend.available() is False
+
+
+# ── provider: reachability-as-auth ────────────────────────────────────────────
+def test_provider_status_and_noop_auth(monkeypatch):
+    p = OllamaProvider()
+    monkeypatch.setattr(OllamaBackend, "available", classmethod(lambda cls, app_id=None: True))
+    st = p.status()
+    assert (st.provider, st.logged_in, st.method) == ("ollama", True, "local")
+    assert p.login().logged_in is True
+    assert p.logout() is None
+    monkeypatch.setattr(OllamaBackend, "available", classmethod(lambda cls, app_id=None: False))
+    assert p.status().logged_in is False
+    with pytest.raises(HunchError):
+        p.login()
+
+
+def test_provider_make_backend():
+    assert isinstance(OllamaProvider().make_backend(_FakeHunch()), OllamaBackend)

--- a/tests/test_ollama_backend.py
+++ b/tests/test_ollama_backend.py
@@ -103,19 +103,37 @@ def test_fallback_parses_prose_tool_call(monkeypatch):
 
 
 def test_fallback_ignores_non_tool_json(monkeypatch):
-    b = _backend([_msg('the config is ```json\n{"volume": 11}\n``` — done')],
-                 monkeypatch=monkeypatch)
+    # 3 identical responses: the no-tool-call reply is nudged twice, then accepted.
+    resp = _msg('the config is ```json\n{"volume": 11}\n``` — done')
+    b = _backend([resp, resp, resp], monkeypatch=monkeypatch)
     r = b.run("read config")
     assert b._calls == [] and r.stop_reason == "end_turn"
-    assert r.usage["fallback_tool_calls"] == 0
+    assert r.usage["fallback_tool_calls"] == 0 and r.usage["continue_nudges"] == 2
 
 
 def test_strict_disables_fallback(monkeypatch):
     monkeypatch.setenv("HUNCH_OLLAMA_STRICT", "1")
     prose = '```json\n{"name": "list_apps", "arguments": {}}\n```'
-    b = _backend([_msg(prose)], monkeypatch=monkeypatch)
+    resp = _msg(prose)
+    b = _backend([resp, resp, resp], monkeypatch=monkeypatch)
     r = b.run("apps?")
     assert b._calls == [] and r.stop_reason == "end_turn"
+
+
+def test_announce_without_act_is_nudged(monkeypatch):
+    # The measured 04/12 failure: a plan narration with no tool call must be pushed
+    # back into acting, and the nudge counted.
+    b = _backend([
+        _msg("I'll read the file and copy the total."),
+        _msg(tool_calls=[{"function": {"name": "list_apps", "arguments": {}}}]),
+        _msg("done"),
+    ], monkeypatch=monkeypatch)
+    r = b.run("do it")
+    assert b._calls == [("list_apps", {})]
+    assert r.usage["continue_nudges"] == 1 and r.text == "done" and not r.aborted
+    # once a tool has run, a no-call response ends the episode (no further nudge)
+    assert [m["content"] for m in b.messages if m.get("role") == "user"][1].startswith(
+        "You have not called any tool")
 
 
 def test_screenshot_bytes_ride_images_channel(monkeypatch):
@@ -136,9 +154,10 @@ def test_max_turns_aborts(monkeypatch):
 
 
 def test_usage_accumulates_and_reset_clears():
-    b = _backend([{**_msg("hi"), "prompt_eval_count": 100, "eval_count": 7}])
+    resp = {**_msg("hi"), "prompt_eval_count": 100, "eval_count": 7}
+    b = _backend([resp, resp, resp])       # nudged twice, so three requests total
     r = b.run("hello")
-    assert (r.usage["input_tokens"], r.usage["output_tokens"]) == (100, 7)
+    assert (r.usage["input_tokens"], r.usage["output_tokens"]) == (300, 21)
     assert b.messages          # conversation kept for continuation
     b.reset()
     assert b.messages == []

--- a/tests/test_ollama_backend.py
+++ b/tests/test_ollama_backend.py
@@ -144,6 +144,37 @@ def test_usage_accumulates_and_reset_clears():
     assert b.messages == []
 
 
+def test_chat_retries_transient_http_errors(monkeypatch):
+    # qwen3.5's tool-template parse flake: Ollama 500s once, then the retry lands.
+    import io
+    attempts = []
+    def flaky_urlopen(req, timeout=None):
+        attempts.append(1)
+        if len(attempts) < 3:
+            raise urllib.error.HTTPError(
+                "u", 500, "err", {},
+                io.BytesIO(b'{"error": "XML syntax error on line 5"}'))
+        class _R:
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+            def read(self): return b'{"message": {"role": "assistant", "content": "hi"}}'
+        return _R()
+    monkeypatch.setattr("urllib.request.urlopen", flaky_urlopen)
+    out = OllamaBackend(_FakeHunch())._chat({"model": "m"})
+    assert out["message"]["content"] == "hi" and len(attempts) == 3
+
+
+def test_chat_gives_up_after_retries(monkeypatch):
+    import io
+    def always_500(req, timeout=None):
+        raise urllib.error.HTTPError("u", 500, "err", {},
+                                     io.BytesIO(b'{"error": "XML syntax error"}'))
+    monkeypatch.setattr("urllib.request.urlopen", always_500)
+    with pytest.raises(HunchError) as e:
+        OllamaBackend(_FakeHunch())._chat({"model": "m"})
+    assert "XML syntax error" in str(e.value)
+
+
 def test_no_server_raises_friendly_hint(monkeypatch):
     b = OllamaBackend(_FakeHunch())
     monkeypatch.setattr(


### PR DESCRIPTION
Adds the local-model transport measured on 2026-08-07: `OllamaBackend` (stdlib urllib against a local Ollama daemon) + an `ollama` provider whose auth surface is a server-reachability check.

- Same loop contract as the `api` backend: playbook system prompt, `AGENT_TOOLS` as native tool schemas, tools executed in-process via `_dispatch_core`.
- `think: false` and an explicit `num_ctx` (default 32768) baked in from the probe measurements — Ollama's own context default can silently truncate the ~6.5k-token playbook.
- The measured playbook-imitation failure mode (well-formed JSON tool calls in prose instead of the native channel) is recovered by a conservative fallback parser and **counted** in `usage['fallback_tool_calls']`; `HUNCH_OLLAMA_STRICT=1` disables it to measure the native channel alone.
- Env knobs: `HUNCH_OLLAMA_MODEL` / `HOST` / `NUM_CTX` / `STRICT`.
- 14 new tests around the faked `_chat` touch-point; full suite 172 pass. No MCP tool added (tool count unchanged).

The bench consumes this via `bench/local_driver.py` + the `hunch-ollama` driver adapter (bench is local/gitignored); after merge, the adapter's `HUNCH_SRC` override can be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)