### PR TITLE
fix: honest AXRow clicks, coerce stringified act(), aim bare snapshot

### DIFF
--- a/src/hunch/local_mac.py
+++ b/src/hunch/local_mac.py
@@ -12,6 +12,7 @@ Requires: Accessibility permission granted to the running process
 
 import os
 import base64
+import json
 import re
 import subprocess
 import tempfile
@@ -859,6 +860,21 @@ class MacSession:
             return self._ax_sweep(parent)
         return None
 
+    def _focused_window_title(self):
+        """Title of this session's focused/main window, or None if unreadable.
+        Used to catch SwiftUI 'AXPress success' lies on sidebar rows (System
+        Settings reports pressed while the pane title stays 'Wallpaper')."""
+        pid = getattr(self, "_pid", None)
+        if pid is None:
+            return None
+        try:
+            win = ax.get_window(AXUIElementCreateApplication(pid))
+            if win is None:
+                return None
+            return str(ax.get_attr(win, ax.kAXTitleAttribute) or "") or None
+        except Exception:  # noqa: BLE001 — best-effort signal only
+            return None
+
     def click(self, ref, allow_pixel=True):
         """Activate the element via the AX layer — occlusion-proof and no cursor
         movement: its own press action, a press-like alternative, a checkbox/switch
@@ -867,8 +883,28 @@ class MacSession:
         then only after deliberately raising the app, because a pixel click both
         moves the shared cursor and lands on whichever window is frontmost."""
         el = self._el(ref)
+        role = str(ax.get_attr(el, ax.kAXRoleAttribute) or "")
+        # Sidebar/list rows are the main SwiftUI false-success surface: AXPress
+        # returns 0 while the pane does not change. Capture the window title so
+        # we can refuse to call that a navigation.
+        before = self._focused_window_title() if role == "AXRow" else None
         msg = self._ax_activate(el)
         if msg:
+            if before is not None:
+                time.sleep(0.35)
+                after = self._focused_window_title()
+                if after == before:
+                    # Selection (not press) is what some sidebars actually honor.
+                    if AXUIElementSetAttributeValue(el, "AXSelected", True) == 0:
+                        time.sleep(0.35)
+                        after = self._focused_window_title()
+                        if after is not None and after != before:
+                            return (f"selected {ref} (navigated {before!r} → {after!r})")
+                    return (f"{msg} {ref} — no navigation: window still {before!r}. "
+                            f"AXPress reported success but the pane did not change "
+                            f"(common in System Settings / SwiftUI). Do not retry the "
+                            f"same click — try the View menu, a different control, or "
+                            f"select() the row.")
             return f"{msg} {ref}"
         if not allow_pixel:
             return f"{ref}: no AX press action; a pixel click would move the shared cursor — skipped"
@@ -1403,7 +1439,31 @@ class LocalComputer:
         x, y = a.get(f"{side}_x"), a.get(f"{side}_y")
         return (int(x), int(y)) if x is not None and y is not None else None
 
+    @staticmethod
+    def _coerce_actions(actions):
+        """Normalize `actions` to a list of dicts. Small local models (and some
+        providers) occasionally pass a JSON *string* instead of an array — iterating
+        that string made every char hit `.get` and raised
+        `'str' object has no attribute 'get'` (seen 2026-08-08 on qwen3.5:9b)."""
+        if isinstance(actions, str):
+            try:
+                actions = json.loads(actions)
+            except (json.JSONDecodeError, TypeError):
+                return None, ("actions must be an array of objects like "
+                              '[{"action":"click","ref":"e12"}], not a string — '
+                              "got a JSON string that doesn't parse. Re-send as a "
+                              "real array, not a stringified one.")
+        if not isinstance(actions, list):
+            return None, (f"actions must be an array of objects, got {type(actions).__name__}")
+        if any(not isinstance(a, dict) for a in actions):
+            return None, ("actions must be an array of objects like "
+                          '[{"action":"click","ref":"e12"}] — each item must be an object')
+        return actions, None
+
     def act(self, actions):
+        actions, bad = self._coerce_actions(actions)
+        if bad:
+            return bad
         sim = self.simultaneous
         _dist_before = dict(self.session.disturbances)
         # Only bring the app forward if the batch actually contains a focus-stealing action.

--- a/src/hunch/sdk.py
+++ b/src/hunch/sdk.py
@@ -138,6 +138,10 @@ class Hunch:
         self._computer = LocalComputer(app=app, simultaneous=simultaneous,
                                        max_depth=snapshot_max_depth,
                                        max_nodes=snapshot_max_nodes)
+        # Last app aim'd by focus_app / launch_app / snapshot(app=...). Empty
+        # snapshot() prefers this over frontmost so a bare snapshot after
+        # focus_app("System Settings") does not silently read Cursor.
+        self._aimed_app = None
         # Namespaced defaults (names only — same semantics): derived CDP port + profile.
         if app_id and cdp_port is None:
             import zlib
@@ -169,19 +173,25 @@ class Hunch:
 
     def snapshot(self, app="", ref=None, max_depth=None, max_nodes=None, max_children=None):
         """The app's focused window as a ref-annotated accessibility tree (focus-free).
-        Empty `app` targets the frontmost app. Pass ref="e42" to expand ONLY that
-        element's subtree at full depth (other refs stay valid). Truncation is never
-        silent: capped output ends in an explicit …marker naming the ref to expand.
-        max_children raises the per-node sibling cap to page a big list in."""
+        Empty `app` targets the last aimed app (focus_app / launch_app /
+        snapshot(app=...)), else the frontmost app. Pass ref="e42" to expand ONLY
+        that element's subtree at full depth (other refs stay valid). Truncation is
+        never silent: capped output ends in an explicit …marker naming the ref to
+        expand. max_children raises the per-node sibling cap to page a big list in."""
         if ref is not None:
             return self._computer.snapshot(ref=ref, max_depth=max_depth, max_nodes=max_nodes,
                                            max_children=max_children)
-        prev = self._computer.app
-        self._computer.app = app or _frontmost()
+        prev, prev_aimed = self._computer.app, self._aimed_app
+        if app:
+            self._computer.app = app
+            self._aimed_app = app
+        else:
+            self._computer.app = self._aimed_app or _frontmost()
         out = self._computer.snapshot(max_depth=max_depth, max_nodes=max_nodes,
                                       max_children=max_children)
         if isinstance(out, str) and out.startswith("(app '") and "not found" in out:
-            self._computer.app = prev   # a failed target must not poison later calls
+            # a failed target must not poison later calls
+            self._computer.app, self._aimed_app = prev, prev_aimed
         return out
 
     def find(self, role=None, name_contains=None, app="", max_results=20):
@@ -189,12 +199,15 @@ class Hunch:
         return only matching elements, each with an actable [ref]. role is
         case-insensitive with the AX prefix optional ("button" == AXButton);
         name_contains matches title/description/value as a substring."""
-        prev = self._computer.app
+        prev, prev_aimed = self._computer.app, self._aimed_app
         if app:
             self._computer.app = app
+            self._aimed_app = app
+        elif self._aimed_app:
+            self._computer.app = self._aimed_app
         out = self._computer.find(role=role, name_contains=name_contains, max_results=max_results)
         if isinstance(out, str) and out.startswith("(app '") and "not found" in out:
-            self._computer.app = prev
+            self._computer.app, self._aimed_app = prev, prev_aimed
         return out
 
     def act(self, actions, reason="", confirm=False):
@@ -202,6 +215,12 @@ class Hunch:
         menu/key/click_xy by ref) and return the updated tree. Focus-stealing actions are
         gated; a user refusal raises ApprovalDenied. StaleRef means re-snapshot.
         confirm=True skips the dialog (the user already approved out-of-band)."""
+        # Coerce before the focus-steal gate so a stringified actions payload
+        # (local-model failure mode) does not blow up on a.get inside the gate.
+        coerced, bad = LocalComputer._coerce_actions(actions)
+        if bad:
+            return bad
+        actions = coerced
         blocked = gate.check_focus_steal(self._computer, actions, self._gate,
                                          confirm=confirm, reason=reason)
         if blocked:
@@ -230,6 +249,7 @@ class Hunch:
         set_focus_reason(reason)
         msg = _launch_app(name, force_accessibility, background=self._computer.simultaneous)
         self._computer.app = name
+        self._aimed_app = name
         refs = self._computer.snapshot().count("[e")
         return (f"{msg}; accessibility tree has {refs} elements"
                 + ("" if refs > 15 else
@@ -246,6 +266,7 @@ class Hunch:
         set_focus_reason(reason)
         msg = _focus_app(name)
         self._computer.app = name
+        self._aimed_app = name
         return msg
 
     @property

--- a/src/hunch/server.py
+++ b/src/hunch/server.py
@@ -51,6 +51,13 @@ _mac = Hunch(
     policy="personal",        # ~/.hunch/config.json live + HUNCH_NO_INTERNAL_GATE, as always
     check_permissions=False,  # AX problems surface per-tool, not at import
     notify=_notify,           # keeps the app-mode banner suppression
+    # HUNCH_SIMULTANEOUS=1 starts the server with the hard focus-free guarantee:
+    # no pixel-click fallback, and shared keyboard/cursor actions are refused
+    # rather than performed. Previously this could only be turned on by the AGENT
+    # calling simultaneous_mode() mid-session, so any embedder — or benchmark —
+    # that forgot inherited an agent free to grab the user's cursor. Making it
+    # settable at startup lets the operator, not the model, own that promise.
+    simultaneous=bool(os.environ.get("HUNCH_SIMULTANEOUS")),
 )
 _gate = _mac._gate            # single Gate: approval state behaves as the old module globals
 _as_str = gate.as_str         # kept aliases (tests + external callers)

--- a/tests/test_ax_press.py
+++ b/tests/test_ax_press.py
@@ -102,6 +102,136 @@ def test_ax_activate_finds_inner_control(monkeypatch):
     assert msg == "pressed (inner control)"
 
 
+def test_click_axrow_false_press_reports_no_navigation(monkeypatch):
+    """System Settings sidebar: AXPress returns success but the pane title does
+    not change — click() must say so instead of claiming a navigation."""
+    s = _bare_session()
+    s.registry = {"e17": "row"}
+    s._pid = 1
+    titles = iter(["Wallpaper", "Wallpaper", "Wallpaper"])  # before, after press, after select
+    monkeypatch.setattr(ax, "get_attr", lambda el, attr:
+                        "AXRow" if attr == ax.kAXRoleAttribute else None)
+    monkeypatch.setattr(lm.MacSession, "_focused_window_title",
+                        lambda self: next(titles))
+    monkeypatch.setattr(lm.MacSession, "_ax_activate", lambda self, el: "pressed")
+    monkeypatch.setattr(lm, "AXUIElementSetAttributeValue", lambda el, attr, v: 0)
+    monkeypatch.setattr(lm.time, "sleep", lambda s: None)
+    out = s.click("e17")
+    assert "no navigation" in out and "Wallpaper" in out
+    assert "Do not retry the same click" in out
+
+
+def test_click_axrow_select_fallback_when_press_lies(monkeypatch):
+    """When AXPress is a no-op, selecting the row can still navigate — report that."""
+    s = _bare_session()
+    s.registry = {"e14": "row"}
+    s._pid = 1
+    titles = iter(["Wallpaper", "Wallpaper", "Accessibility"])
+    monkeypatch.setattr(ax, "get_attr", lambda el, attr:
+                        "AXRow" if attr == ax.kAXRoleAttribute else None)
+    monkeypatch.setattr(lm.MacSession, "_focused_window_title",
+                        lambda self: next(titles))
+    monkeypatch.setattr(lm.MacSession, "_ax_activate", lambda self, el: "pressed")
+    monkeypatch.setattr(lm, "AXUIElementSetAttributeValue", lambda el, attr, v: 0)
+    monkeypatch.setattr(lm.time, "sleep", lambda s: None)
+    out = s.click("e14")
+    assert "selected e14" in out and "Accessibility" in out
+
+
+def test_click_axrow_real_nav_reports_pressed(monkeypatch):
+    """When the pane title actually changes after AXPress, treat it as success —
+    no select fallback, no 'no navigation' warning."""
+    s = _bare_session()
+    s.registry = {"e3": "row"}
+    s._pid = 1
+    titles = iter(["Wallpaper", "Accessibility"])
+    monkeypatch.setattr(ax, "get_attr", lambda el, attr:
+                        "AXRow" if attr == ax.kAXRoleAttribute else None)
+    monkeypatch.setattr(lm.MacSession, "_focused_window_title",
+                        lambda self: next(titles))
+    monkeypatch.setattr(lm.MacSession, "_ax_activate", lambda self, el: "pressed")
+    monkeypatch.setattr(lm.time, "sleep", lambda s: None)
+    selects = []
+    monkeypatch.setattr(lm, "AXUIElementSetAttributeValue",
+                        lambda el, attr, v: selects.append(attr) or 0)
+    out = s.click("e3")
+    assert out == "pressed e3"
+    assert "no navigation" not in out
+    assert selects == []  # title already changed — don't poke AXSelected
+
+
+def test_click_non_row_skips_title_verify(monkeypatch):
+    """Buttons/switches keep the old path — no window-title probe."""
+    s = _bare_session()
+    s.registry = {"e9": "btn"}
+    titles = []
+    monkeypatch.setattr(ax, "get_attr", lambda el, attr:
+                        "AXButton" if attr == ax.kAXRoleAttribute else None)
+    monkeypatch.setattr(lm.MacSession, "_focused_window_title",
+                        lambda self: titles.append("x") or "x")
+    monkeypatch.setattr(lm.MacSession, "_ax_activate", lambda self, el: "pressed")
+    out = s.click("e9")
+    assert out == "pressed e9"
+    assert titles == []
+
+
+def test_coerce_actions_accepts_json_string():
+    """Local models sometimes pass actions as a JSON string, not an array."""
+    ok, err = lm.LocalComputer._coerce_actions(
+        '[{"action":"click","ref":"e12"}]')
+    assert err is None and ok == [{"action": "click", "ref": "e12"}]
+
+
+def test_coerce_actions_accepts_list_of_dicts():
+    actions = [{"action": "click", "ref": "e1"}]
+    ok, err = lm.LocalComputer._coerce_actions(actions)
+    assert err is None and ok is actions
+
+
+def test_coerce_actions_rejects_garbage_string():
+    """Unparseable stringified actions (e.g. ref:e17 without quotes) get a clear
+    error — never `'str' object has no attribute 'get'`."""
+    ok, err = lm.LocalComputer._coerce_actions(
+        '[{"action":"click","ref":e17}]')  # invalid JSON
+    assert ok is None and "array of objects" in err
+
+
+def test_coerce_actions_rejects_non_list_and_bad_items():
+    ok, err = lm.LocalComputer._coerce_actions({"action": "click"})
+    assert ok is None and "array of objects" in err
+    ok, err = lm.LocalComputer._coerce_actions(["click", {"action": "click"}])
+    assert ok is None and "each item must be an object" in err
+
+
+def test_act_string_actions_do_not_crash(monkeypatch):
+    lc = object.__new__(lm.LocalComputer)
+    lc.simultaneous = True
+    lc.session = _bare_session()
+    lc._last_snap = "=== Fake ===\n"
+    monkeypatch.setattr(lm.LocalComputer, "snapshot", lambda self, **k: "=== Fake ===\n")
+    monkeypatch.setattr(lm.time, "sleep", lambda s: None)
+    out = lc.act('[{"action":"click","ref":e17}]')  # the exact 2026-08-08 failure shape
+    assert "array of objects" in out
+    assert "attribute 'get'" not in out
+
+
+def test_act_parses_valid_json_string_and_runs(monkeypatch):
+    """A well-formed stringified array must coerce and execute, not error."""
+    lc = object.__new__(lm.LocalComputer)
+    lc.simultaneous = True
+    lc.session = _bare_session()
+    lc.session.disturbances = {"pixel_clicks": 0, "keystrokes": 0, "key_combos": 0,
+                               "app_raises": 0, "drags": 0}
+    lc._last_snap = "=== Fake ===\n"
+    clicks = []
+    monkeypatch.setattr(lm.LocalComputer, "snapshot", lambda self, **k: "=== Fake ===\n")
+    monkeypatch.setattr(lm.MacSession, "click", lambda self, ref, **k: clicks.append(ref) or f"pressed {ref}")
+    monkeypatch.setattr(lm.time, "sleep", lambda s: None)
+    out = lc.act('[{"action":"click","ref":"e12"}]')
+    assert clicks == ["e12"]
+    assert "pressed e12" in out
+
+
 def test_click_pixel_fallback_refuses_without_activation(monkeypatch):
     """No AX vocabulary anywhere and the app can't be raised: the click must be
     refused — never post cursor events blind."""

--- a/tests/test_sdk_smoke.py
+++ b/tests/test_sdk_smoke.py
@@ -309,6 +309,97 @@ def test_simultaneous_property():
     assert h._computer.simultaneous is True
 
 
+def test_snapshot_empty_app_prefers_aimed_after_focus(monkeypatch):
+    """Regression (AX-nav sweep 2026-08-08): after focus_app('System Settings'),
+    a bare snapshot() must NOT silently read the frontmost app (often Cursor)."""
+    h = _client()
+    seen = []
+
+    def fake_snapshot(self, ref=None, max_depth=None, max_nodes=None, max_children=None):
+        seen.append(self.app)
+        return f"=== {self.app} — focused window (snapshot #1) ===\n"
+
+    monkeypatch.setattr(h._computer.__class__, "snapshot", fake_snapshot)
+    monkeypatch.setattr(hunch.sdk, "_frontmost", lambda: "Cursor")
+    monkeypatch.setattr(hunch.sdk, "_focus_app", lambda name: f"focused {name}")
+    h.focus_app("System Settings", reason="test")
+    out = h.snapshot()  # empty app
+    assert seen[-1] == "System Settings"
+    assert "System Settings" in out
+    # Explicit app still wins, and retargets aim.
+    h.snapshot(app="Notes")
+    assert seen[-1] == "Notes"
+    h.snapshot()
+    assert seen[-1] == "Notes"
+
+
+def test_find_and_launch_also_set_aimed_app(monkeypatch):
+    h = _client()
+    seen = []
+
+    def fake_snapshot(self, ref=None, max_depth=None, max_nodes=None, max_children=None):
+        seen.append(("snap", self.app))
+        return f"=== {self.app} ===\n[e1] AXButton\n"
+
+    def fake_find(self, role=None, name_contains=None, max_results=20):
+        seen.append(("find", self.app))
+        return f"[e1] in {self.app}"
+
+    monkeypatch.setattr(h._computer.__class__, "snapshot", fake_snapshot)
+    monkeypatch.setattr(h._computer.__class__, "find", fake_find)
+    monkeypatch.setattr(hunch.sdk, "_frontmost", lambda: "Cursor")
+    monkeypatch.setattr(hunch.sdk, "_launch_app",
+                        lambda name, force=False, background=False: f"launched {name}")
+    h.launch_app("Mail", reason="test")
+    assert h._aimed_app == "Mail"
+    h.find(role="button")  # bare find → aimed Mail, not Cursor
+    assert seen[-1] == ("find", "Mail")
+    h.find(role="button", app="Notes")
+    assert h._aimed_app == "Notes"
+    assert seen[-1] == ("find", "Notes")
+
+
+def test_failed_snapshot_does_not_poison_aimed_app(monkeypatch):
+    h = _client()
+    monkeypatch.setattr(hunch.sdk, "_frontmost", lambda: "Cursor")
+    monkeypatch.setattr(hunch.sdk, "_focus_app", lambda name: f"focused {name}")
+    h.focus_app("System Settings", reason="test")
+
+    def boom(self, ref=None, max_depth=None, max_nodes=None, max_children=None):
+        return "(app 'BogusApp' not found — is it running?)"
+
+    monkeypatch.setattr(h._computer.__class__, "snapshot", boom)
+    out = h.snapshot(app="BogusApp")
+    assert "not found" in out
+    assert h._aimed_app == "System Settings"  # failed aim rolled back
+
+
+def test_sdk_act_coerces_string_before_focus_gate(monkeypatch):
+    """Stringified actions must fail with a clear message, not AttributeError
+    inside gate.check_focus_steal (a.get)."""
+    h = _client()
+    called = []
+
+    def boom(computer, actions, g, confirm=False, reason=""):
+        called.append(actions)
+        # Would have crashed pre-fix: for c in actions: a.get(...)
+        for a in actions:
+            a.get("action")
+        return None
+
+    monkeypatch.setattr(gate, "check_focus_steal", boom)
+    out = h.act('[{"action":"click","ref":e17}]')
+    assert "array of objects" in out
+    assert called == []  # never reached the gate
+
+
+def test_hunch_constructor_honors_simultaneous_flag():
+    """server.py wires HUNCH_SIMULTANEOUS into this constructor arg."""
+    h = Hunch(check_permissions=False, confirm="off", simultaneous=True)
+    assert h.simultaneous is True
+    assert h._computer.simultaneous is True
+
+
 if __name__ == "__main__":
     mod = sys.modules[__name__]
     for name in sorted(n for n in dir(mod) if n.startswith("test_")):


### PR DESCRIPTION
## Summary
- Detect SwiftUI false `AXPress` success on `AXRow` clicks (System Settings sidebar): verify window title change, try `AXSelected`, otherwise report **no navigation** instead of claiming success.
- Coerce `act(actions=...)` when local models pass a JSON *string* (or other bad shapes) so we return a clear error instead of `'str' object has no attribute 'get'`.
- Bare `snapshot()` / `find()` prefer the last aimed app from `focus_app` / `launch_app` / explicit `app=` so post-focus reads don't silently hit Cursor; failed targets don't poison aim.
- Honor `HUNCH_SIMULTANEOUS` at MCP server startup so operators (and benches) can enforce focus-free without relying on the model.

## Test plan
- [x] `.venv/bin/python -m pytest tests/` (176 passed)
- [ ] Optional live smoke: `focus_app("System Settings")` then bare `snapshot()` — tree should be Settings, not Cursor
- [ ] Optional: click a System Settings sidebar `AXRow` that doesn't navigate — response should mention `no navigation` rather than bare `pressed`


Made with [Cursor](https://cursor.com)