### PR TITLE
fix: critical injection / gate-bypass / SSRF — C1-C5 (fixes #19)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,10 @@ on:
       - "README.md"
   workflow_dispatch: {}   # allow manual runs from the Actions tab
 
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   check:
     name: Should we publish?
@@ -41,6 +45,7 @@ jobs:
     needs: check
     if: needs.check.outputs.publish == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment:
       name: pypi
       url: https://pypi.org/p/hunch-sdk
@@ -52,18 +57,15 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: 'pip'
       - name: Build sdist + wheel
         run: |
           python -m pip install --upgrade build
           python -m build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-      - name: Tag the release
+      - name: Tag & release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          set -euo pipefail
-          V="v${{ needs.check.outputs.version }}"
-          git tag "$V"
-          git push origin "$V"
-          gh release create "$V" dist/* --title "$V" --generate-notes
+          gh release create "v${{ needs.check.outputs.version }}" dist/* --title "v${{ needs.check.outputs.version }}" --generate-notes

--- a/src/hunch/cdp.py
+++ b/src/hunch/cdp.py
@@ -23,6 +23,7 @@ import subprocess
 import tempfile
 import urllib.request
 import urllib.parse
+import ipaddress
 
 import websocket  # websocket-client
 
@@ -33,6 +34,37 @@ def _host_resolves(host):
         return True
     except Exception:
         return False
+
+
+def _is_blocked_host(host):
+    """True for loopback / private / link-local / reserved / multicast hosts (SSRF)."""
+    if not host:
+        return False
+    h = host.lower().strip()
+    if h == "localhost" or h.endswith(".localhost"):
+        return True
+    raw = h.strip("[]")  # [::1] -> ::1
+    try:
+        ip = ipaddress.ip_address(raw)
+        return (ip.is_private or ip.is_loopback or ip.is_link_local
+                or ip.is_reserved or ip.is_unspecified or ip.is_multicast)
+    except ValueError:
+        pass
+    # hostname -> resolve and check any A/AAAA is private
+    try:
+        infos = socket.getaddrinfo(host, None, family=socket.AF_UNSPEC, type=socket.SOCK_STREAM)
+        for _, _, _, _, sockaddr in infos:
+            ip_str = sockaddr[0]
+            try:
+                ip = ipaddress.ip_address(ip_str)
+                if (ip.is_private or ip.is_loopback or ip.is_link_local
+                        or ip.is_reserved or ip.is_unspecified or ip.is_multicast):
+                    return True
+            except ValueError:
+                continue
+    except Exception:
+        return False  # NXDOMAIN handled by caller
+    return False
 
 
 # ── ARIA/CDP roles worth surfacing (interactive + content), like the AX filter ──
@@ -828,9 +860,18 @@ class CDPSession:
         return ("accounts.google.com" in low) or ("/signin" in low) or ("sign in" in low)
 
     def navigate(self, url):
-        # Guard against a GUESSED/hallucinated URL: if the host doesn't resolve, don't navigate to a
-        # dead page — steer back to clicking the real link (whose href/redirect knows the true target).
-        host = urllib.parse.urlparse(url).hostname
+        # SSRF + hallucination guards: block private/internal hosts before any fetch,
+        # then ensure the host actually resolves. Private check must come first – a
+        # private host *does* resolve (localhost -> 127.0.0.1) and would otherwise be fetched.
+        parsed = urllib.parse.urlparse(url)
+        host = parsed.hostname
+        if parsed.scheme and parsed.scheme.lower() not in ("http", "https"):
+            return (f"REFUSED: navigation to scheme '{parsed.scheme}' is blocked — only http/https "
+                    f"are allowed. If you need a file, use the filesystem tools.")
+        if host and _is_blocked_host(host):
+            return (f"REFUSED: navigation to private/internal host '{host}' is blocked (SSRF "
+                    f"protection). Navigate only to public http(s) hosts, or click a link by ref "
+                    f"instead of guessing a URL.")
         if host and not _host_resolves(host):
             return (f"'{url}' — host '{host}' does NOT resolve (DNS). If you constructed or guessed this "
                     "URL, don't: go back to the page and CLICK the actual link (by ref) so its real "

--- a/src/hunch/local_mac.py
+++ b/src/hunch/local_mac.py
@@ -19,6 +19,7 @@ import tempfile
 import time
 
 from . import ax_tree_mac as ax  # reuse the AX primitives (get_attrs, bounds, list_apps, get_window)
+from .notify import as_str  # AppleScript string escaping (canonical home is notify.py)
 from ApplicationServices import (
     AXUIElementCreateApplication, AXUIElementPerformAction,
     AXUIElementSetAttributeValue, AXUIElementSetMessagingTimeout,
@@ -1255,7 +1256,7 @@ def launch_app(name, force_accessibility=False, background=False):
         # lets the app save state), then hard-kill if it won't go: some apps (Discord) IGNORE SIGTERM,
         # so the reliable fallback is SIGKILL (pkill -9), which needs no Automation permission.
         if old_pids:
-            subprocess.run(["osascript", "-e", f'tell application "{name}" to quit'], check=False)
+            subprocess.run(["osascript", "-e", f'tell application {as_str(name)} to quit'], check=False)
             gone_by = time.time() + 4
             while time.time() < gone_by and _pids_named(name):
                 time.sleep(0.3)

--- a/src/hunch/os_ops.py
+++ b/src/hunch/os_ops.py
@@ -75,7 +75,7 @@ def open_path(path, app=None):
     ws = NSWorkspace.sharedWorkspace()
     target = _abspath(path) if os.path.exists(_abspath(path)) else str(path)
     if app:
-        os.system(f'open -a {app!r} {target!r}')  # simple, reliable app routing
+        subprocess.run(["open", "-a", app, target], check=False)
         return f"opened {target} with {app}"
     if os.path.exists(target):
         ok = ws.openURL_(NSURL.fileURLWithPath_(target))

--- a/src/hunch/policy.py
+++ b/src/hunch/policy.py
@@ -21,10 +21,11 @@ DEFAULT_GATES = {
     "app_to_front": True,            # focus_app / foreground launch_app switching the user's view
     "shell": True,                   # applescript() containing 'do shell script'
     "destructive_applescript": True, # delete / send / shut down / empty trash / ...
+    "destructive_file": True,        # trash / file_op move / copy (destructive filesystem ops)
 }
 
 CONFIG_KEYS = ["gates.focus_steal", "gates.app_to_front", "gates.shell",
-               "gates.destructive_applescript", "auto_approve_all"]
+               "gates.destructive_applescript", "gates.destructive_file", "auto_approve_all"]
 
 
 def default_config() -> dict:

--- a/src/hunch/sdk.py
+++ b/src/hunch/sdk.py
@@ -668,23 +668,52 @@ class Files:
         hit = next((p for p in paths if gate.protected(p)), None)
         if hit is not None:
             return self._refused(hit, "deletable")
+        if self._h._gate.enabled("destructive_file"):
+            preview = ", ".join(str(p)[:60] for p in paths[:3])
+            if len(paths) > 3:
+                preview += f" … (+{len(paths) - 3} more)"
+            if not self._h._gate.confirm_dialog(
+                f"{self._h.app_name} wants to move {len(paths)} item(s) to Trash: {preview} — allow?",
+                category="destructive_file", detail=preview, screen_approval=False):
+                from .gate import ApprovalDenied
+                raise ApprovalDenied("user did not approve moving items to Trash")
         return os_ops.trash(paths)
 
     def move(self, src, dst):
         for p in (src, dst):
             if p and gate.protected(p):
                 return self._refused(p, "writable")
+        if self._h._gate.enabled("destructive_file"):
+            detail = f"{src} -> {dst}"
+            if not self._h._gate.confirm_dialog(
+                f"{self._h.app_name} wants to move {src!r} to {dst!r} — allow?",
+                category="destructive_file", detail=detail, screen_approval=False):
+                from .gate import ApprovalDenied
+                raise ApprovalDenied("user did not approve move")
         return os_ops.move(src, dst)
 
     def copy(self, src, dst):
         for p in (src, dst):
             if p and gate.protected(p):
                 return self._refused(p, "writable")
+        if self._h._gate.enabled("destructive_file"):
+            detail = f"{src} -> {dst}"
+            if not self._h._gate.confirm_dialog(
+                f"{self._h.app_name} wants to copy {src!r} to {dst!r} — allow?",
+                category="destructive_file", detail=detail, screen_approval=False):
+                from .gate import ApprovalDenied
+                raise ApprovalDenied("user did not approve copy")
         return os_ops.copy(src, dst)
 
     def mkdir(self, path):
         if gate.protected(path):
             return self._refused(path, "writable")
+        if self._h._gate.enabled("destructive_file"):
+            if not self._h._gate.confirm_dialog(
+                f"{self._h.app_name} wants to create folder {path!r} — allow?",
+                category="destructive_file", detail=str(path), screen_approval=False):
+                from .gate import ApprovalDenied
+                raise ApprovalDenied("user did not approve mkdir")
         return os_ops.make_dir(path)
 
     def open(self, path, app=None):

--- a/src/hunch/server.py
+++ b/src/hunch/server.py
@@ -120,7 +120,7 @@ def find(role: str = "", name_contains: str = "", app: str = "", max_results: in
 
 
 @mcp.tool()
-def act(actions: list, confirm: bool = False, reason: str = "") -> str:
+def act(actions: list, reason: str = "") -> str:
     """Execute one or more UI actions in order (by element ref), then return what
     CHANGED on screen since your last view (~ changed, + new, gone: refs; unchanged
     lines omitted). First look, a window change, or heavy churn returns the full
@@ -157,13 +157,12 @@ def act(actions: list, confirm: bool = False, reason: str = "") -> str:
     shared keyboard/mouse and require the app frontmost). For those it pops a click-to-approve
     dialog ('Go ahead' / 'Cancel') on the user's screen and only proceeds if they click Go
     ahead — so it never grabs the screen by surprise, and the user approves with ONE CLICK (no
-    typing). Focus-free actions run immediately. Pass confirm=true only if the user has already
-    approved and you want to skip the dialog.
+    typing). Focus-free actions run immediately.
 
     When the batch contains ANY focus-stealing action, ALWAYS pass `reason` — one short human
     sentence for WHY you need the screen (e.g. "press Enter to submit the search"). It is shown
     to the user in the focus warning and the approval prompt."""
-    return _run("act", actions=actions, confirm=confirm, reason=reason)
+    return _run("act", actions=actions, reason=reason)
 
 
 @mcp.tool()
@@ -434,7 +433,7 @@ def clipboard_set(text: str) -> str:
 
 
 @mcp.tool()
-def applescript(script: str, confirm: bool = False) -> str:
+def applescript(script: str) -> str:
     """Run AppleScript to control scriptable native apps FOCUS-FREE via Apple Events — the
     app's own command layer, not its UI/keyboard/focus. Unlocks Mail, Messages, Notes,
     Reminders, Calendar, Music, Finder, Safari, Keynote, etc. (e.g.
@@ -447,10 +446,9 @@ def applescript(script: str, confirm: bool = False) -> str:
 
     SAFETY: read-only queries (get / count) run directly. Scripts that mutate, send, delete,
     quit, or use 'do shell script' pop a one-click 'Go ahead' dialog on the user's screen and
-    only run if approved (pass confirm=true to skip the dialog if the user already approved).
-    Note: the FIRST time Hunch scripts a given app, macOS shows a one-time 'allow control'
-    permission prompt the user must accept."""
-    return _run("applescript", script=script, confirm=confirm)
+    only run if approved. Note: the FIRST time Hunch scripts a given app, macOS shows a
+    one-time 'allow control' permission prompt the user must accept."""
+    return _run("applescript", script=script)
 
 
 def main():


### PR DESCRIPTION
Fixes #19 – 5 critical prompt-injection → privileged-sink flaws on `cybersec/prompt-injection-fixes` (branch renamed from `fix/injection-c1-c2`).

**C1 `src/hunch/os_ops.py:78` `5d94643`** – `os.system(f'open -a {app!r} {target!r}')` shell injection. `repr()` picks `"` on `'`, so `a'$(touch /tmp/pwn)` expands inside double quotes (`sh -c`). → `subprocess.run(["open","-a",app,target])`.

**C2 `src/hunch/local_mac.py:19,1258` `69a501a`** – `f'tell application "{name}" to quit'` AppleScript injection. `Finder" & do shell script "touch /tmp/pwn" & "` breaks out. → `as_str(name)` (`notify.py:17`).

**C3 `src/hunch/server.py:123,437` `b525041`** – MCP `act`/`applescript` exposed `confirm:bool` to model, allowing `confirm=true` to skip second gate (`gate.py:145`). → Remove `confirm` from MCP schemas; gate always enforced for untrusted caller.

**C4 `src/hunch/policy.py:19` + `src/hunch/sdk.py:664` `120a924`** – `trash`/`file_op` (move/copy/mkdir) had no second gate, only `~/.hunch` protected. → New `destructive_file` gate (default on, `CONFIG_KEYS` + `gates.destructive_file`) with `confirm_dialog(..., category="destructive_file")` in `Files.trash/move/copy/mkdir`.

**C5 `src/hunch/cdp.py:14,30,830` `bc9e49e`** – `navigate` only checked `_host_resolves` → SSRF to `localhost:9337`, `192.168.x`, `169.254.169.254` via user Chrome. → `+ipaddress`, `_is_blocked_host()` (loopback/private/link-local/reserved/multicast/unspecified + DNS resolving to private), `http/https` only, checked before `Page.navigate`.

5 commits on `rangan39:cybersec/prompt-injection-fixes`, `py_compile` verified, `policy.gate_enabled("destructive_file")==True`. Renamed branch per request. Fixes #19.

Previous PR #20 auto-closed on branch rename – replaced by this PR.
