### PR TITLE
Make notifications opt-in and add test CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
       - name: Install package and test runner
-        run: python -m pip install . pytest
+        run: python -m pip install '.[agent]' pytest
       - name: Run tests
         run: python -m pytest tests/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,21 @@ jobs:
         run: python -m pip install '.[agent]' pytest
       - name: Run tests
         run: python -m pytest tests/
+
+  package:
+    name: Build package
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install build tools
+        run: python -m pip install build twine
+      - name: Build wheel and source distribution
+        run: python -m build
+      - name: Validate package metadata
+        run: python -m twine check dist/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Python ${{ matrix.python-version }}
+    runs-on: macos-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install package and test runner
+        run: python -m pip install . pytest
+      - name: Run tests
+        run: python -m pytest tests/

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ mac = Hunch(
                                         #   profile, and CDP port; never a behavior switch
     app_name="Acme Mailbot",            # what consent dialogs + notifications say
     confirm=my_consent_callback,        # ConsentRequest -> bool, rendered in YOUR UI
-    notify=my_toast_handler,            # (message, title) -> your surface, not macOS banners
+    notify=my_toast_handler,            # callback, or True for native macOS banners (default: off)
     policy={"gates": {"shell": True}},  # instance-owned safety; the user's personal
                                         #   config can never disarm your app
     auth=OAuthToken(token),             # the exact Claude subscription token YOUR app manages
@@ -323,6 +323,10 @@ metadata) via its file tools; permission changes are for humans in a terminal.
 | `HUNCH_NO_INTERNAL_GATE=1` | suppress all internal dialogs (for host apps that run their own approval UX) |
 | `HUNCH_FORCE_SANDBOX=1` | web layer uses a throwaway, logged-out browser profile |
 | `HUNCH_NOTIFY_FOCUS=0` | silence the "Hunch is switching apps" notifications (they fire only for switches no dialog asked about) |
+
+User-attention desktop notifications are opt-in. For the personal MCP server, enable them with
+`hunch config set notifications.user_attention on`. SDK apps can pass `notify=True` for native
+macOS banners or a `notify(message, title)` callback for their own UI; the default is disabled.
 
 ## FAQ
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-  "mcp>=1.2",
+  "mcp>=1.2,<2",
   "websocket-client>=1.6",
   "pyobjc-framework-Cocoa>=10.0",
   "pyobjc-framework-ApplicationServices>=10.0",

--- a/src/hunch/agent.py
+++ b/src/hunch/agent.py
@@ -134,7 +134,8 @@ AGENT_TOOLS = [
                            "isolated": {"type": "boolean"}})},
     {"name": "web_login",
      "description": ("Open a background, banner-tagged window for the HUMAN to sign in once (Hunch "
-                     "never sees the password); the login then persists. Fires a desktop notification."),
+                     "never sees the password); the login then persists. Uses the configured "
+                     "user-attention notification when enabled."),
      "input_schema": _obj({"app": {"type": "string"}, "url": {"type": "string"}})},
     {"name": "web_snapshot",
      "description": "Read the CDP-controlled page as an accessibility tree. Call web_open first.",
@@ -292,7 +293,10 @@ def _set_simultaneous(mac, on):
 
 
 def _notify(mac, message):
-    mac.notify(message, f"{getattr(mac, 'app_name', 'Hunch')} needs you")
+    delivered = mac.notify(message, f"{getattr(mac, 'app_name', 'Hunch')} needs you")
+    if delivered is False:
+        return ("user-attention notifications are disabled; ask the user directly in your "
+                f"response: {message}")
     return f"notified the user: {message}"
 
 

--- a/src/hunch/cli.py
+++ b/src/hunch/cli.py
@@ -73,7 +73,8 @@ def _print_config():
     for key in policy.CONFIG_KEYS:
         val = policy.get(cfg, key)
         if val is None:
-            val = policy.DEFAULT_GATES.get(key.split(".", 1)[-1], False)
+            val = (policy.DEFAULT_GATES.get(key.split(".", 1)[-1], False)
+                   if key.startswith("gates.") else False)
         effective = policy.gate_enabled(key.split(".", 1)[-1]) if key.startswith("gates.") else val
         note = ""
         if env_override and key.startswith("gates."):
@@ -91,7 +92,7 @@ def cmd_config(args):
         return 0
     if args.action == "reset":
         policy.save(policy.default_config())
-        print("config reset to defaults (all gates on).")
+        print("config reset to defaults (all gates on; user-attention notifications off).")
         return 0
     # set
     key, value = args.key, args.value

--- a/src/hunch/playbook.py
+++ b/src/hunch/playbook.py
@@ -68,8 +68,8 @@ KEY WORKFLOWS:
   `do shell script`, or AppleScript UI-clicks to flip System Settings — those paths are refused and
   often write the wrong key while the pane stays unchanged. Sidebar rows (Spotlight, Motion, …): if
   click reports "no navigation", `select` the row or use the View menu — do not grind the same click.
-- Sign into a site: `web_login(app, url)` opens a background banner-tagged window and notifies
-  the user; then wait for their "done".
+- Sign into a site: `web_login(app, url)` opens a background banner-tagged window and uses the
+  configured user-attention notification when enabled; then wait for their "done".
 - Log in with SAVED credentials: if `list_credentials` shows a service, `web_open` the site then
   `web_fill_login(service)` — Hunch types the saved email+password straight into the page and you
   NEVER see the values; then submit via `web_act`. No saved credential? Use `web_login` instead.

--- a/src/hunch/policy.py
+++ b/src/hunch/policy.py
@@ -25,12 +25,18 @@ DEFAULT_GATES = {
 }
 
 CONFIG_KEYS = ["gates.focus_steal", "gates.app_to_front", "gates.shell",
-               "gates.destructive_applescript", "gates.destructive_file", "auto_approve_all"]
+               "gates.destructive_applescript", "gates.destructive_file",
+               "notifications.user_attention", "auto_approve_all"]
 
 
 def default_config() -> dict:
     return {"version": 1, "auto_approve_all": False, "auto_approve_warned": False,
-            "gates": dict(DEFAULT_GATES)}
+            "gates": dict(DEFAULT_GATES), "notifications": {"user_attention": False}}
+
+
+def user_attention_notifications_enabled() -> bool:
+    """Whether the personal MCP server may send unsolicited desktop banners."""
+    return bool(get(load(), "notifications.user_attention"))
 
 
 def load() -> dict:

--- a/src/hunch/sdk.py
+++ b/src/hunch/sdk.py
@@ -60,7 +60,7 @@ class Hunch:
                  simultaneous=False, cdp_port=None,
                  snapshot_max_depth=None, snapshot_max_nodes=None,
                  provider="claude", auth=None, can_use_tool=None, app_name=None, policy=None,
-                 app_id=None, cdp_profile=None, notify=None):
+                 app_id=None, cdp_profile=None, notify=False):
         """provider: which LLM vendor drives the agent loop — 'claude' (Anthropic, on your
         Claude sign-in; the default) or 'codex' (OpenAI Codex, on a `codex login` session).
         Set once here; then mac.login() / mac.status() / mac.logout() and mac.agent all act
@@ -95,8 +95,9 @@ class Hunch:
         legacy/personal names (what the MCP server uses).
 
         cdp_profile: browser profile dir override (default derives from app_id).
-        notify: callable(message, title) replacing system notifications with your own
-        surface (e.g. an in-app toast)."""
+        notify: False/None (default) disables user-attention notifications; True opts
+        into native macOS banners; a callable(message, title) routes them through your
+        own surface (e.g. an in-app toast)."""
         if isinstance(policy, dict):
             unknown = set(policy.get("gates", {})) - set(_policy_mod.DEFAULT_GATES)
             if unknown:
@@ -106,11 +107,12 @@ class Hunch:
             if not app_id or not all(c.isalnum() or c in "._-" for c in app_id):
                 raise HunchError(f"invalid app_id {app_id!r} — use letters, digits, '.', "
                                  "'_', '-' (reverse-DNS style, e.g. 'com.acme.mailbot')")
-        if notify is not None and not callable(notify):
-            raise HunchError("notify must be a callable(message, title) or None")
+        if not (notify is None or isinstance(notify, bool) or callable(notify)):
+            raise HunchError("notify must be True, False, None, or a callable(message, title)")
         self.app_id = app_id
         self._app_id = app_id            # what Agent/_SubscriptionRunner read
-        self._notify_handler = notify
+        self._notify_handler = notify if callable(notify) else None
+        self._native_notifications = notify is True
         self.app_name = app_name or (app_id.split(".")[-1].replace("-", " ").replace("_", " ")
                                      .title() if app_id else "Hunch")
         try:
@@ -305,13 +307,14 @@ class Hunch:
         return f"AppleScript error: {out[:600]}{gate.applescript_hint(out)}"
 
     def notify(self, message, title=None):
-        """Notify the user: through the instance's notify handler if one was given
-        (your app's own surface), else a macOS desktop notification titled app_name."""
+        """Notify the user when explicitly configured; return whether it was delivered."""
         title = title or self.app_name
         if self._notify_handler is not None:
-            self._notify_handler(message, title)
-            return
+            return self._notify_handler(message, title) is not False
+        if not self._native_notifications:
+            return False
         _notify(message, title, sound="Ping")
+        return True
 
     def list_credentials(self):
         """Names + kinds of saved credentials (never any values). Fill them into a CDP
@@ -504,8 +507,8 @@ class Web:
 
     def login(self, url="", app="Google Chrome"):
         """Open a background, banner-tagged window for the HUMAN to sign in once (Hunch
-        never sees the password). Fires a desktop notification; the login persists in
-        the Hunch profile."""
+        never sees the password). Uses the configured user-attention notification, if
+        enabled; the login persists in the Hunch profile."""
         from .cdp import CDPComputer, quit_cdp
         self.close()
         quit_cdp(self.port)  # fresh window, no stale-instance reuse
@@ -520,10 +523,12 @@ class Web:
             s.navigate(url)
         s.wait_ready()
         s.mark()
-        self._h.notify("Switch to the green 'HUNCH — LOG IN HERE' window to sign in.",
-                       f"{self._h.app_name} needs you to sign in")
-        return ("opened a background, banner-tagged window and sent a notification — "
-                "have the user sign in there and leave it open, then continue")
+        notified = self._h.notify(
+            "Switch to the green 'HUNCH — LOG IN HERE' window to sign in.",
+            f"{self._h.app_name} needs you to sign in")
+        notice = "sent the configured notification" if notified else "notifications are disabled"
+        return (f"opened a background, banner-tagged window; {notice} — have the user sign "
+                "in there and leave it open, then continue")
 
     def restart(self, url="", app="Google Chrome"):
         """Quit and reopen the CDP instance fresh (same persistent profile, login kept).

--- a/src/hunch/server.py
+++ b/src/hunch/server.py
@@ -19,6 +19,7 @@ from mcp.server.fastmcp import FastMCP, Image
 
 from .playbook import HUNCH_PLAYBOOK
 from . import gate
+from . import policy
 from .notify import notify as _notify_impl
 
 
@@ -35,11 +36,14 @@ def _notify(message, title="Hunch"):
     In app mode the Hunch popover re-surfaces itself instead (the app pops it when the
     notify_user / web_login tool event streams through), so the banner would be a duplicate."""
     if _APP_OWNS_PERMS:
-        return
+        return True  # the host app re-surfaces itself from the streamed tool event
+    if not policy.user_attention_notifications_enabled():
+        return False
     try:
         _notify_impl(message, title, sound="Ping")
+        return True
     except Exception:
-        pass
+        return False
 
 
 # ── ONE Hunch instance: the engine behind every tool ──────────────────────────────
@@ -256,11 +260,12 @@ def web_login(app: str = "Google Chrome", url: str = "") -> str:
     `app` is the BROWSER name (default "Google Chrome"); `url` is the site's login/home page
     (e.g. "https://mail.google.com/") — do not pass a website as `app`.
     Opens the browser in the BACKGROUND at that URL (it does NOT steal focus), in a window
-    tagged with a green '🟢 HUNCH — LOG IN HERE' banner, and fires a desktop notification.
+    tagged with a green '🟢 HUNCH — LOG IN HERE' banner and uses the configured
+    user-attention notification when enabled.
     The user switches to that window on their own schedule and signs in themselves (Hunch
     never sees the password); the session then persists, and all later web_open / web_act
-    calls run focus-free. Tell the user a notification was sent and to switch to the
-    banner-tagged window when ready, sign in, leave it open, and confirm when done."""
+    calls run focus-free. Tell the user to switch to the banner-tagged window when ready,
+    sign in, leave it open, and confirm when done."""
     return _run("web_login", app=app, url=url)
 
 
@@ -374,8 +379,9 @@ def web_fill_secret(service: str, ref: str = "") -> str:
 def notify_user(message: str) -> str:
     """Alert the user when Hunch needs them SHORTLY — to finish a login, approve a 2FA /
     verification prompt, solve a captcha, or make a decision. Brings the Hunch window back up
-    (or fires a desktop notification when running outside the app). Call this the moment you
-    hit a step only the human can do, so they don't have to watch the screen."""
+    (or fires a desktop notification when running outside the app and the user enabled
+    `notifications.user_attention`). Call this the moment you hit a step only the human can
+    do, so they don't have to watch the screen."""
     return _run("notify_user", message=message)
 
 

--- a/tests/test_sdk_smoke.py
+++ b/tests/test_sdk_smoke.py
@@ -162,6 +162,18 @@ def test_notify_handler_routing():
         assert "notify" in str(e)
 
 
+def test_notifications_are_opt_in(monkeypatch):
+    sent = []
+    monkeypatch.setattr("hunch.sdk._notify", lambda *args, **kwargs: sent.append((args, kwargs)))
+    h = Hunch(check_permissions=False, confirm="off")
+    assert h.notify("quiet") is False
+    assert sent == []
+
+    enabled = Hunch(check_permissions=False, confirm="off", notify=True)
+    assert enabled.notify("hello") is True
+    assert len(sent) == 1
+
+
 def test_protected_covers_app_dirs():
     assert gate.protected(os.path.expanduser("~/.hunch/apps/com.acme.mailbot/creds_index.json"))
     assert gate.protected(os.path.expanduser("~/.hunch/config.json"))
@@ -258,6 +270,19 @@ def test_server_is_an_app_on_the_sdk():
     assert server._gate is server._mac._gate
     assert server._gate._policy == "personal"
     assert server._mac._notify_handler is server._notify
+
+
+def test_server_notifications_follow_personal_config(monkeypatch):
+    sent = []
+    monkeypatch.setattr(server, "_APP_OWNS_PERMS", False)
+    monkeypatch.setattr(server.policy, "user_attention_notifications_enabled", lambda: False)
+    monkeypatch.setattr(server, "_notify_impl", lambda *args, **kwargs: sent.append((args, kwargs)))
+    assert server._notify("quiet") is False
+    assert sent == []
+
+    monkeypatch.setattr(server.policy, "user_attention_notifications_enabled", lambda: True)
+    assert server._notify("needed") is True
+    assert len(sent) == 1
 
 
 def test_server_run_delegation(monkeypatch):

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -70,6 +70,16 @@ def test_app_to_front_gate_default_on():
     assert "gates.app_to_front" in policy.CONFIG_KEYS
 
 
+def test_user_attention_notifications_default_off(monkeypatch, tmp_path):
+    monkeypatch.setattr(policy, "CONFIG_PATH", str(tmp_path / "config.json"))
+    assert "notifications.user_attention" in policy.CONFIG_KEYS
+    assert policy.user_attention_notifications_enabled() is False
+    cfg = policy.default_config()
+    policy.set_key(cfg, "notifications.user_attention", True)
+    policy.save(cfg)
+    assert policy.user_attention_notifications_enabled() is True
+
+
 def test_screen_approval_dedupe():
     import hunch.local_mac as local_mac
     # A fresh approval lets the front gate pass with NO dialog...


### PR DESCRIPTION
## Summary
- disable SDK user-attention notifications by default
- add explicit `notify=True` native-banner opt-in while preserving callback routing
- add live `notifications.user_attention` configuration for the personal MCP server
- report accurately when `notify_user` or `web_login` cannot deliver a notification
- add a macOS GitHub Actions test matrix for Python 3.11, 3.12, and 3.13
- build the wheel and source distribution in CI and validate their metadata with Twine
- constrain `mcp` to the compatible 1.x API; clean CI installs exposed that MCP 2.x breaks the current `FastMCP` imports

## Testing
- local full working-tree suite: `215 passed`
- GitHub Actions: package verification and Python 3.11, 3.12, and 3.13 all passing