### PR TITLE
Fix false macOS permission diagnoses

### DIFF
--- a/src/hunch/gate.py
+++ b/src/hunch/gate.py
@@ -170,15 +170,32 @@ def applescript_category(script):
             else None)
 
 
-def applescript_hint(out):
-    """Permission-aware suffix for an AppleScript error (TCC denials), or ""."""
-    if "assistive access" in out.lower() or "-25211" in out:
-        return (" — macOS blocked this: the app hosting Hunch lacks the Accessibility "
+def applescript_hint(out, script=""):
+    """Classification suffix for explicit AppleScript/TCC failures, or "".
+
+    Timeouts and empty results are deliberately not permission evidence. Protected database
+    access is a separate Full Disk Access capability and should fall back to the supported UI
+    path rather than teaching the agent to request a broad grant.
+    """
+    low = (out or "").lower()
+    script_low = (script or "").lower()
+    denied = any(k in low for k in ("authorization denied", "operation not permitted",
+                                     "permission denied"))
+    messages_db = "library/messages/chat.db" in low or "library/messages/chat.db" in script_low
+    if denied and messages_db:
+        return (" [FULL_DISK_ACCESS_REQUIRED] Direct access to Messages chat.db is blocked by "
+                "macOS Full Disk Access, which is separate from Hunch's normal Accessibility, "
+                "Automation, and Screen Recording permissions. Do not ask the user to grant it "
+                "by default; continue through Messages AppleScript or snapshot/act instead.")
+    if "assistive access" in low or "-25211" in low:
+        return (" [ACCESSIBILITY_DENIED] macOS explicitly blocked this: the app hosting Hunch "
+                "lacks the Accessibility "
                 "permission. Tell the user: System Settings → Privacy & Security → "
                 "Accessibility, enable the MCP host app (toggle off/on if already listed), "
                 "then restart it. `hunch doctor` explains.")
-    if "not authorized" in out.lower() or "-1743" in out:
-        return (" — Automation consent missing for the target app. macOS shows a one-time "
+    if "not authorized" in low or "-1743" in low:
+        return (" [AUTOMATION_DENIED] macOS explicitly denied Automation access to the target "
+                "app. macOS shows a one-time "
                 "'allow control' prompt on first use; if it was denied, tell the user to "
                 "re-enable it in System Settings → Privacy & Security → Automation.")
     return ""

--- a/src/hunch/os_ops.py
+++ b/src/hunch/os_ops.py
@@ -107,6 +107,16 @@ def run_applescript(script, timeout=60):
         with os.fdopen(fd, "w") as f:
             f.write(script)
         r = subprocess.run(["osascript", path], capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        # A timeout is operationally ambiguous: the target app may be busy, the query may be
+        # expensive, or macOS may have a consent sheet open. Never turn that ambiguity into a
+        # claim that a permission is missing; only osascript's explicit TCC errors establish it.
+        return False, (
+            f"[APPLESCRIPT_TIMEOUT] AppleScript exceeded {timeout} seconds. This result is "
+            "inconclusive and does NOT prove a macOS permission problem. Try one smaller query, "
+            "then switch to another available layer instead of requesting permissions. Only "
+            "report an Automation denial when osascript explicitly returns -1743 or "
+            "'not authorized'.")
     except Exception as e:  # noqa: BLE001
         return False, str(e)
     finally:

--- a/src/hunch/playbook.py
+++ b/src/hunch/playbook.py
@@ -14,7 +14,10 @@ the Music/Spotify app (not open.spotify.com), files → Finder/OS-API (not drive
 files). Check `list_apps` (or launch_app's error) if unsure what's installed. Drop to the website
 only when: no native app is installed, the native app isn't signed into the needed account (e.g.
 Mail has no accounts configured), or the capability genuinely exists only on the web — and say
-which of those it was. The browser is the fallback, not the default.
+which of those it was. For an explicitly named webmail account (for example, an @gmail.com address),
+make at most one small native account probe; if it times out or cannot confirm that account, use the
+signed-in website instead of grinding on Mail or asking for permissions. The browser is the fallback,
+not the default.
 STAY NATIVE even for embedded-Chromium apps (Electron/CEF: Discord, Slack, Spotify…). Even hardened
 ones that strip the CDP debug port ARE readable focus-free as a TREE: `snapshot(app)` auto-relaunches
 the app once with the accessibility flag (focus-free `open -g`; the app restores its prior view) so
@@ -113,6 +116,16 @@ KEY WORKFLOWS:
   `web_login` (have the user sign into that window once; it persists).
 - You need the human (sign-in, 2FA, a decision, review-before-submit): call `notify_user(msg)`
   so they get a desktop alert — never stall silently.
+- PERMISSION CLAIMS REQUIRE EXPLICIT EVIDENCE: never infer a missing macOS permission from a
+  timeout, empty AppleScript result, empty/near-empty tree, or an app being slow. A timeout is over
+  (nothing is still running): say it ended, try at most one smaller query, then switch layers. Only
+  tell the user a permission is missing when the tool result explicitly identifies
+  `ACCESSIBILITY_DENIED`, `AUTOMATION_DENIED`, or `FULL_DISK_ACCESS_REQUIRED` (or includes the
+  corresponding explicit macOS denial). Keep those capabilities distinct.
+- MESSAGES HISTORY: do not read `~/Library/Messages/chat.db` or ask for Full Disk Access by default.
+  Full Disk Access is broader than Hunch's normal permissions. Use Messages AppleScript and the AX
+  `snapshot`/`act` path; if the only remaining step needs foreground paging, explain that specific
+  focus requirement and ask through the normal focus gate.
 - APP RESISTS EVERY LAYER: `snapshot` already auto-relaunches an embedded-Chromium app with the
   accessibility flag, so most Electron/CEF apps DO yield a tree. Only if `snapshot` STILL reads an
   empty/near-empty tree after that one-time force relaunch (and `web_open` can't attach a debug port)

--- a/src/hunch/sdk.py
+++ b/src/hunch/sdk.py
@@ -302,7 +302,7 @@ class Hunch:
         if ok:
             hint = "" if out else gate.applescript_empty_hint(script)
             return f"(no output){hint}" if hint else out
-        return f"AppleScript error: {out[:600]}{gate.applescript_hint(out)}"
+        return f"AppleScript error: {out[:600]}{gate.applescript_hint(out, script)}"
 
     def notify(self, message, title=None):
         """Notify the user: through the instance's notify handler if one was given

--- a/src/hunch/server.py
+++ b/src/hunch/server.py
@@ -447,7 +447,11 @@ def applescript(script: str) -> str:
     SAFETY: read-only queries (get / count) run directly. Scripts that mutate, send, delete,
     quit, or use 'do shell script' pop a one-click 'Go ahead' dialog on the user's screen and
     only run if approved. Note: the FIRST time Hunch scripts a given app, macOS shows a
-    one-time 'allow control' permission prompt the user must accept."""
+    one-time 'allow control' permission prompt the user must accept.
+
+    ERROR EVIDENCE: a timeout or empty result does NOT establish a permission problem. Only
+    report missing permissions when the result explicitly says ACCESSIBILITY_DENIED,
+    AUTOMATION_DENIED, or FULL_DISK_ACCESS_REQUIRED."""
     return _run("applescript", script=script)
 
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -5,6 +5,7 @@ Needs pyobjc (imports the server) but touches no Keychain items and no UI.
 """
 
 import os
+import subprocess
 import sys
 import tomllib
 from pathlib import Path
@@ -141,6 +142,45 @@ def test_applescript_empty_result_explains_electron_zero_windows():
     assert gate.applescript_empty_hint('tell application "System Events" to keystroke "a"') == ""
 
 
+def test_applescript_timeout_is_inconclusive(monkeypatch):
+    """A slow query is not proof that Automation permission is missing."""
+    from hunch import os_ops
+
+    def time_out(*args, **kwargs):
+        raise subprocess.TimeoutExpired(args[0], kwargs["timeout"])
+
+    monkeypatch.setattr(os_ops.subprocess, "run", time_out)
+    ok, message = os_ops.run_applescript('tell application "Mail" to get name of every account',
+                                         timeout=3)
+    assert ok is False
+    assert message.startswith("[APPLESCRIPT_TIMEOUT]")
+    assert "does NOT prove" in message
+    assert "AUTOMATION_DENIED" not in message
+
+
+def test_applescript_permission_hints_require_explicit_evidence():
+    from hunch import gate
+
+    assert gate.applescript_hint("query timed out after 60 seconds") == ""
+    assert gate.applescript_hint("nothing was returned") == ""
+    assert "AUTOMATION_DENIED" in gate.applescript_hint(
+        "Not authorized to send Apple events to Mail. (-1743)")
+    assert "ACCESSIBILITY_DENIED" in gate.applescript_hint(
+        "osascript is not allowed assistive access. (-25211)")
+
+
+def test_messages_database_denial_prefers_supported_ui_fallback():
+    from hunch import gate
+
+    hint = gate.applescript_hint(
+        "sqlite3: authorization denied while opening database",
+        'do shell script "sqlite3 ~/Library/Messages/chat.db ..."')
+    assert "FULL_DISK_ACCESS_REQUIRED" in hint
+    assert "separate from Hunch's normal" in hint
+    assert "Do not ask the user to grant it" in hint
+    assert "snapshot/act" in hint
+
+
 def test_applescript_settings_refusal_blocks_defaults_and_ui_script():
     """Freeze miss mode: agents invent defaults write / System Events clicks for Settings."""
     from hunch import gate
@@ -159,6 +199,9 @@ def test_playbook_covers_toggle_and_select_policy():
     assert "val='0'" in pb and "val='1'" in pb
     assert "defaults write" in pb
     assert "VISIBLE TEXT" in pb
+    assert "PERMISSION CLAIMS REQUIRE EXPLICIT EVIDENCE" in pb
+    assert "do not read `~/Library/Messages/chat.db`" in pb
+    assert "make at most one small native account probe" in pb
 
 
 def test_twin_process_warning_names_which_copy_the_tree_is(monkeypatch):


### PR DESCRIPTION
## Summary

- classify AppleScript timeouts as inconclusive instead of permission failures
- label only explicit TCC denials as Automation or Accessibility failures
- distinguish blocked Messages database reads as Full Disk Access and prefer the supported UI fallback
- route explicitly named webmail accounts to the signed-in website after one failed native probe
- teach the agent never to claim missing permissions from timeouts, empty results, or empty trees

## Tests

- `PYTHONPATH=/tmp/hunch-permission-pr/src /Users/prithviseran/hunch-mcp/.venv/bin/python -m pytest tests/`
- 192 passed
