### PR TITLE
Release 0.6.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hunch-sdk"
-version = "0.6.2"
+version = "0.6.3"
 description = "Drive your Mac focus-free over MCP: OS APIs, AppleScript, CDP, and Accessibility."
 readme = "README.md"
 license = "Apache-2.0"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.PrithviSeran/hunch",
   "description": "Focus-free macOS control for AI agents: drive your real Mac apps in the background, no stolen focus.",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "repository": {
     "url": "https://github.com/PrithviSeran/hunch-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "pypi",
       "identifier": "hunch-sdk",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "transport": {
         "type": "stdio"
       }

--- a/src/hunch/__init__.py
+++ b/src/hunch/__init__.py
@@ -5,7 +5,7 @@ doctor) must work even when pyobjc or the MCP SDK are missing, so nothing here
 may import them. The server loads lazily via `hunch serve`.
 """
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"
 
 # Public SDK surface, loaded lazily (PEP 562) so bare `import hunch` stays dependency-free.
 # Names mapped to .sdk/.agent/.local_mac pull in pyobjc; .errors/.auth/.providers stay


### PR DESCRIPTION
## Summary
- bump the Python package version to `0.6.3`
- keep the runtime `__version__` aligned
- bump both MCP registry version markers in `server.json`

This release packages the notification configuration, MCP dependency compatibility fix, and permission-diagnosis changes already merged into `main`.

## Verification
- `195 passed` on the clean release branch
- built `hunch_sdk-0.6.3.tar.gz` and `hunch_sdk-0.6.3-py3-none-any.whl` successfully

After merge, the existing publish workflow will detect that `0.6.3` is absent from PyPI and publish it.