### PR TITLE
Release 0.6.4: explicit runtime capability recovery

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,14 +30,17 @@ jobs:
           set -euo pipefail
           VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          # 200 => this version already exists on PyPI; anything else => new.
+          # Only a confirmed absent version enables publishing.
           CODE=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/hunch-sdk/$VERSION/json")
           if [ "$CODE" = "200" ]; then
             echo "hunch-sdk $VERSION already on PyPI — skipping."
             echo "publish=false" >> "$GITHUB_OUTPUT"
-          else
+          elif [ "$CODE" = "404" ]; then
             echo "hunch-sdk $VERSION is new — will publish."
             echo "publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Unexpected PyPI response: $CODE" >&2
+            exit 1
           fi
 
   publish:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ the product. Most gotchas below exist to protect it.
 ```
 
 - Python ≥ 3.11. Depends on **pyobjc** (AppKit/ApplicationServices/Quartz) — macOS only.
-- `tests/test_smoke.py::test_tool_count` asserts **exactly 29 MCP tools**. Adding/removing a
+- `tests/test_smoke.py::test_tool_count` asserts **exactly 32 MCP tools**. Adding/removing a
   tool means updating that number in the same commit, on purpose.
 - Tests fake all AX/Quartz calls (`monkeypatch`), so they run headless with no UI and touch
   no Keychain. Keep new logic unit-testable this way: put the OS call behind a function you
@@ -27,7 +27,7 @@ The SDK is the product; everything else is an app built on it.
 
 - **`sdk.py`** — `Hunch`, the developer-facing SDK object (instance-owned policy, auth
   injection `ApiKey`/`OAuthToken`/`"none"`, `app_id` namespacing, notify handler).
-- **`server.py`** — the MCP server, **an app built ON the SDK** (the first one). 29
+- **`server.py`** — the MCP server, **an app built ON the SDK** (the first one). 32
   `@mcp.tool()` functions each call `_run(name, ...)` → `agent._dispatch_core`. Its only
   "personal machine" specialness is constructor args (`policy="personal"`, Hunch branding).
 - **`agent.py`** — the agent loop (`Agent.run`), two backends: **api** (`anthropic`, metered)
@@ -107,10 +107,9 @@ resort. Concretely:
   `AXMainWindow` (via `get_window`), **not `window 1` by index**. A modal **sheet** (save panel,
   a locked-note password prompt) can *be* window 1; index-based resize hits the sheet. It reads
   the geometry back and reports the actual result (windows clamp/refuse).
-- **Embedded Chromium/Electron** (Discord, Slack, VS Code, Spotify…) don't expose their web-content
-  AX tree in the background. `launch_app(force_accessibility=True)` relaunches with
-  `--force-renderer-accessibility` so the tree persists; `AXManualAccessibility` helps while
-  frontmost. Detected via bundled `Electron Framework`/`Chromium Embedded Framework`.
+- **Embedded Chromium/Electron** coverage depends on the process, operation, permissions,
+  and window state. Observation never restarts applications. Explicit recovery can enable AX
+  or request a graceful accessibility/debugging restart; verify the resulting operation.
 - **When the AX tree is genuinely empty** (a SwiftUI *custom canvas* like the Shortcuts editor:
   ~5 nodes, all placeholder text), there is **no lower level to read** — `AXUIElement` is the
   floor of the public API and reads what the app *published*. `AXEnhancedUserInterface` /

--- a/README.md
+++ b/README.md
@@ -349,11 +349,11 @@ Privacy & Security → Screen Recording, or just let agents use `snapshot`, whic
 permission grants. Toggle the host off and on under Accessibility (and Screen Recording, if you
 use it), then restart the host.
 
-**An app's tree reads empty or shows only a sidebar.** Two different situations. Electron/CEF
-apps (Discord, Slack, Spotify, VS Code) need an accessibility flag; `snapshot` relaunches them
-once, in the background, to set it. Master-detail and Catalyst apps (WhatsApp, Mail) expose only
-the pane you're in: the agent should click into an item by ref and re-snapshot; the detail pane
-then appears. Also check the app actually has a window open.
+**An app's tree reads empty or shows only a sidebar.** Coverage depends on the operation,
+process, permissions, and window state. `snapshot` never restarts an app. Use `app_target`
+to inspect the exact process/window, then `app_capabilities` to inspect bounded recovery
+options. `app_recover` can execute an authorized accessibility or debugging recovery.
+Verify the resulting operation; an empty tree does not establish that an app lacks AX.
 
 **The web layer won't connect.** Chrome 136+ blocks the CDP debug port on your default profile, so
 Hunch drives its own Chrome (a separate data dir at `~/.hunch/chrome-cdp`), not your everyday one.

--- a/docs/releases/0.6.4.md
+++ b/docs/releases/0.6.4.md
@@ -1,0 +1,9 @@
+# Hunch 0.6.4 — runtime capability recovery
+
+Native reads no longer restart applications. Exact app/process/window selection and expiring recovery plans replace app-wide assumptions about accessibility. CDP attachment verifies endpoint ownership (including inherited sockets), pins Electron renderers, and preserves target/profile identity. Shared-input policy applies at execution, and detailed action receipts distinguish dispatch from verified final-field effects. Exact-PID activation falls back to System Events when AppKit cannot activate a verified target.
+
+The runtime catalog has 32 tools, including app_target, app_capabilities, and app_recover. Hunch Learn, installed-operation tools, Rust engines, and native packaging are explicitly excluded and remain in the original checkout for a separate PR.
+
+Validation includes runtime regression tests, denied-input and stale-target cases, ChatGPT background Settings navigation, Cursor background terminal input, and fresh dependency installation. Release-branch test and artifact results are recorded in the PR description. Live provider tasks require a compatible provider runtime; Codex cannot inherit callbacks or pre-attached sessions. General panel postconditions remain future work. App-specific overlays are outside verified background workflow claims.
+
+Version 0.6.4 is set in Python package and MCP registry metadata. Merging to main triggers PyPI publication when that version is absent. Creating the PR does not publish or merge it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hunch-sdk"
-version = "0.6.3"
+version = "0.6.4"
 description = "Drive your Mac focus-free over MCP: OS APIs, AppleScript, CDP, and Accessibility."
 readme = "README.md"
 license = "Apache-2.0"
@@ -24,6 +24,7 @@ classifiers = [
 ]
 dependencies = [
   "mcp>=1.2,<2",
+  "jsonschema>=4.20",
   "websocket-client>=1.6",
   "pyobjc-framework-Cocoa>=10.0",
   "pyobjc-framework-ApplicationServices>=10.0",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.PrithviSeran/hunch",
   "description": "Focus-free macOS control for AI agents: drive your real Mac apps in the background, no stolen focus.",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "repository": {
     "url": "https://github.com/PrithviSeran/hunch-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "pypi",
       "identifier": "hunch-sdk",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "transport": {
         "type": "stdio"
       }

--- a/src/hunch/__init__.py
+++ b/src/hunch/__init__.py
@@ -5,7 +5,7 @@ doctor) must work even when pyobjc or the MCP SDK are missing, so nothing here
 may import them. The server loads lazily via `hunch serve`.
 """
 
-__version__ = "0.6.3"
+__version__ = "0.6.4"
 
 # Public SDK surface, loaded lazily (PEP 562) so bare `import hunch` stays dependency-free.
 # Names mapped to .sdk/.agent/.local_mac pull in pyobjc; .errors/.auth/.providers stay

--- a/src/hunch/agent.py
+++ b/src/hunch/agent.py
@@ -35,186 +35,8 @@ DEFAULT_MODEL = "claude-opus-4-8"
 
 # ── tool schemas ──────────────────────────────────────────────────────────────
 # The full-input action item (native AX layer). Shared by the `act` tool.
-_ACTION_ITEM = {
-    "type": "object",
-    "properties": {
-        "action": {"type": "string",
-                   "enum": ["click", "right_click", "select", "type", "menu", "key", "window", "drag", "click_xy"]},
-        "ref": {"type": "string"}, "text": {"type": "string"},
-        "path": {"type": "array", "items": {"type": "string"}},
-        "key": {"type": "string"}, "modifiers": {"type": "array", "items": {"type": "string"}},
-        "x": {"type": "integer"}, "y": {"type": "integer"}, "w": {"type": "integer"}, "h": {"type": "integer"},
-        "app": {"type": "string"},
-        "from_ref": {"type": "string"}, "to_ref": {"type": "string"},
-        "from_x": {"type": "integer"}, "from_y": {"type": "integer"},
-        "to_x": {"type": "integer"}, "to_y": {"type": "integer"}},
-    "required": ["action"]}
-
-# The web/CDP action item. Its coordinates are renderer-local and focus-free, unlike native pixels.
-_WEB_ACTION_ITEM = {
-    "type": "object",
-    "properties": {
-        "action": {"type": "string", "enum": ["click", "click_xy", "drag", "type", "key", "navigate"]},
-        "ref": {"type": "string"}, "text": {"type": "string"},
-        "key": {"type": "string"}, "modifiers": {"type": "array", "items": {"type": "string"}},
-        "url": {"type": "string"}, "x": {"type": "number"}, "y": {"type": "number"},
-        "from_x": {"type": "number"}, "from_y": {"type": "number"},
-        "to_x": {"type": "number"}, "to_y": {"type": "number"}},
-    "required": ["action"]}
-
-
-def _obj(props=None, required=None):
-    return {"type": "object", "properties": props or {}, **({"required": required} if required else {})}
-
-
-# Names identical to the MCP tools so every HUNCH_PLAYBOOK reference resolves. Descriptions
-# are condensed (the deep procedural guidance lives in the playbook system prompt); each keeps
-# the prescriptive when-to-call sentence, which measurably lifts should-call rate on Opus.
-AGENT_TOOLS = [
-    {"name": "snapshot",
-     "description": ("See an app as an accessibility tree ([ref] per element) — your primary way "
-                     "to read UI focus-free. Pass an app name or leave blank for the frontmost. "
-                     "ref='e42' re-walks just that element's subtree; truncated trees end in `…` "
-                     "markers naming what was dropped."),
-     "input_schema": _obj({"app": {"type": "string"}, "ref": {"type": "string"},
-                           "max_depth": {"type": "integer"}, "max_nodes": {"type": "integer"},
-                           "max_children": {"type": "integer"}})},
-    {"name": "find",
-     "description": ("Search an app's WHOLE tree for matching elements without reading a full "
-                     "snapshot — the cheap way to locate one control in a big window. Filter by "
-                     "role (e.g. 'button', case-insensitive) and/or name_contains (substring of "
-                     "title/description/value). Returns actable [ref]s."),
-     "input_schema": _obj({"role": {"type": "string"}, "name_contains": {"type": "string"},
-                           "app": {"type": "string"}, "max_results": {"type": "integer"}})},
-    {"name": "act",
-     "description": ("Run UI actions in order by ref, then get what CHANGED on screen (unchanged lines omitted; snapshot gives the full tree). To tile/position a window use the 'window' verb (x/y/w/h, focus-free, targets the main window; pass `app` to target a specific app — to tile TWO apps give each window action its own `app`, e.g. app:'TextEdit' x:0 then app:'Notes' x:756). Verbs: click "
-                     "(activate), right_click (context menu), select (highlight a row), type (set "
-                     "a field by ref = focus-free; no ref types at focus = STEALS FOCUS), menu "
-                     "(invoke a menu-bar path, e.g. ['File','Move to Trash'] — the focus-free "
-                     "stand-in for ⌘-shortcuts), key/click_xy (STEAL FOCUS, last resort). Prefer "
-                     "the focus-free verbs. Pass `reason` when any action steals focus."),
-     "input_schema": _obj({"actions": {"type": "array", "items": _ACTION_ITEM},
-                           "reason": {"type": "string"}}, ["actions"])},
-    {"name": "screenshot",
-     "description": ("See the frontmost app as a PNG — only for genuinely visual content the tree "
-                     "can't convey (an image, a chart). To read UI text or check an action, "
-                     "re-snapshot instead. Image pixels are in point space, so a coordinate read "
-                     "here can go straight to a click_xy action."),
-     "input_schema": _obj()},
-    {"name": "list_apps", "description": "List the running GUI apps you can target with snapshot.",
-     "input_schema": _obj()},
-    {"name": "launch_app",
-     "description": ("Launch or focus an app (reliable OS call — beats clicking the Dock). Set "
-                     "force_accessibility=true for an Electron/Chromium app whose tree reads empty. "
-                     "In simultaneous mode it launches in the background."),
-     "input_schema": _obj({"name": {"type": "string"},
-                           "force_accessibility": {"type": "boolean"},
-                           "reason": {"type": "string"}}, ["name"])},
-    {"name": "simultaneous_mode",
-     "description": ("Toggle simultaneous mode. ON = never steal the user's cursor/keyboard/view "
-                     "(background reads, focus-free actions only, shared-input actions refused). "
-                     "OFF = may bring apps forward and use the full input set."),
-     "input_schema": _obj({"on": {"type": "boolean"}})},
-    {"name": "quit_app", "description": "Quit an app via the OS (reliable regardless of focus).",
-     "input_schema": _obj({"name": {"type": "string"}}, ["name"])},
-    {"name": "focus_app",
-     "description": ("Bring an app to the front and target it. This switches the user's view — "
-                     "always pass `reason` (one short sentence for why)."),
-     "input_schema": _obj({"name": {"type": "string"}, "reason": {"type": "string"}}, ["name"])},
-    {"name": "web_open",
-     "description": ("Open a Chromium browser or Electron app for FOCUS-FREE control over CDP — "
-                     "the way to drive web/Electron apps in the background. `app` is the browser "
-                     "(default 'Google Chrome'); put a website in `url`. Uses the persistent Hunch "
-                     "profile; call web_login once if it isn't signed in. CODE EDITORS: app="
-                     "'Cursor'/'Visual Studio Code'/'VSCodium'/'Windsurf' with the FOLDER/FILE in "
-                     "`url` opens a dedicated background editor window whose integrated TERMINAL you "
-                     "can type into (AX can't write it) — snapshot, then web_act 'type' on the "
-                     "'Terminal' tab (trailing newline runs the command); key ctrl+` opens one."),
-     "input_schema": _obj({"app": {"type": "string"}, "url": {"type": "string"},
-                           "isolated": {"type": "boolean"}})},
-    {"name": "web_login",
-     "description": ("Open a background, banner-tagged window for the HUMAN to sign in once (Hunch "
-                     "never sees the password); the login then persists. Uses the configured "
-                     "user-attention notification when enabled."),
-     "input_schema": _obj({"app": {"type": "string"}, "url": {"type": "string"}})},
-    {"name": "web_snapshot",
-     "description": "Read the CDP-controlled page as an accessibility tree. Call web_open first.",
-     "input_schema": _obj()},
-    {"name": "web_screenshot",
-     "description": ("PNG of the CDP page itself (focus-free) — for visual web content the tree "
-                     "can't convey. Use this, never the OS screenshot, for the background browser."),
-     "input_schema": _obj()},
-    {"name": "web_act",
-     "description": ("Run focus-free page actions, then get the updated tree. Verbs: click (by ref), "
-                     "click_xy/drag (coordinates from web_screenshot; canvas editors), type "
-                     "(with ref REPLACES a field; without ref types at current focus), key, navigate "
-                     "(only to a URL you were given or read from the page — click links, don't guess)."),
-     "input_schema": _obj({"actions": {"type": "array", "items": _WEB_ACTION_ITEM}}, ["actions"])},
-    {"name": "web_restart",
-     "description": ("Recover a BROKEN CDP browser by quitting and reopening it fresh (login kept). "
-                     "Last resort — don't restart a merely-slow page; wait and re-snapshot first."),
-     "input_schema": _obj({"app": {"type": "string"}, "url": {"type": "string"}})},
-    {"name": "web_tabs",
-     "description": "List the open CDP tabs (index, title, URL, which is current).",
-     "input_schema": _obj()},
-    {"name": "web_switch_tab",
-     "description": "Switch the CDP session to a tab by index (see web_tabs), then web_snapshot.",
-     "input_schema": _obj({"index": {"type": "integer"}}, ["index"])},
-    {"name": "list_credentials",
-     "description": ("List the service NAMES the user saved credentials for (names + kind only, "
-                     "never values). Fill them with web_fill_login / web_fill_secret."),
-     "input_schema": _obj()},
-    {"name": "web_fill_login",
-     "description": ("Fill the current CDP page's login form from the user's saved credential for "
-                     "`service`, WITHOUT the values entering your context — you only learn which "
-                     "fields were filled. Then submit via web_act. web_open first."),
-     "input_schema": _obj({"service": {"type": "string"}}, ["service"])},
-    {"name": "web_fill_secret",
-     "description": ("Type the user's saved protected value (API key/token) for `service` into a "
-                     "field on the current CDP page, WITHOUT the value entering your context. "
-                     "web_snapshot first and pass the field's ref."),
-     "input_schema": _obj({"service": {"type": "string"}, "ref": {"type": "string"}}, ["service"])},
-    {"name": "notify_user",
-     "description": ("Alert the user when you need them SHORTLY — to finish a login, approve a 2FA "
-                     "prompt, solve a captcha, or make a decision only they can. Call this the moment "
-                     "you hit a step only the human can do."),
-     "input_schema": _obj({"message": {"type": "string"}}, ["message"])},
-    {"name": "request_focus",
-     "description": ("Ask the user's permission BEFORE a focus-stealing step you'll do via other "
-                     "tools. Pops a one-click Go ahead / Cancel dialog and returns their choice."),
-     "input_schema": _obj({"reason": {"type": "string"}}, ["reason"])},
-    {"name": "trash",
-     "description": ("Move file(s)/folder(s) to the Trash by path — focus-free and reversible. Use "
-                     "this to delete files instead of driving Finder."),
-     "input_schema": _obj({"paths": {"type": "array", "items": {"type": "string"}}}, ["paths"])},
-    {"name": "file_op",
-     "description": ("Focus-free filesystem ops by path: op='move'|'copy' (src -> dst) or op='mkdir' "
-                     "(create a folder at src). For MULTIPLE operations pass batch=[{op,src,dst},...] "
-                     "in ONE call (e.g. sort a whole folder at once). To delete, use trash."),
-     "input_schema": _obj({"op": {"type": "string", "enum": ["move", "copy", "mkdir"]},
-                           "src": {"type": "string"}, "dst": {"type": "string"},
-                           "batch": {"type": "array", "items": {
-                               "type": "object", "properties": {
-                                   "op": {"type": "string", "enum": ["move", "copy", "mkdir"]},
-                                   "src": {"type": "string"}, "dst": {"type": "string"}},
-                               "required": ["op", "src"]}}})},
-    {"name": "open_file",
-     "description": ("Open a file/folder/URL/app-deep-link with its default (or a named) app — "
-                     "focus-free launch (also 'mailto:', 'spotify:track:...')."),
-     "input_schema": _obj({"path": {"type": "string"}, "app": {"type": "string"}}, ["path"])},
-    {"name": "reveal_in_finder",
-     "description": "Reveal/select item(s) in a Finder window by path (this does front Finder).",
-     "input_schema": _obj({"paths": {"type": "array", "items": {"type": "string"}}}, ["paths"])},
-    {"name": "clipboard_get", "description": "Read the clipboard's text — focus-free (no ⌘C).",
-     "input_schema": _obj()},
-    {"name": "clipboard_set", "description": "Put text on the clipboard — focus-free (no ⌘V).",
-     "input_schema": _obj({"text": {"type": "string"}}, ["text"])},
-    {"name": "applescript",
-     "description": ("Run AppleScript to control scriptable native apps FOCUS-FREE via Apple Events "
-                     "— Mail, Messages, Notes, Reminders, Calendar, Music, Finder, Safari. Prefer "
-                     "this over UI-driving those apps. Risky scripts prompt the user."),
-     "input_schema": _obj({"script": {"type": "string"}}, ["script"])},
-]
+from .tool_registry import catalog, catalog_for, _ACTION_ITEM, _WEB_ACTION_ITEM, _obj
+AGENT_TOOLS = catalog()
 
 AGENT_ADDENDUM = """\
 
@@ -254,7 +76,8 @@ _DISPATCH = {
     # `confirm` isn't in the agent tool schema (an agent must not self-approve); the MCP
     # server's tools DO pass it through when the human already approved out-of-band.
     "act": lambda m, a: m.act(a.get("actions", []), reason=a.get("reason", ""),
-                              confirm=a.get("confirm", False)),
+                              confirm=a.get("confirm", False), detailed=a.get("detailed", False),
+                              postcondition=a.get("postcondition")),
     "screenshot": lambda m, a: m.screenshot(),
     "list_apps": lambda m, a: m.list_apps(),
     "launch_app": lambda m, a: m.launch_app(a["name"], force_accessibility=a.get("force_accessibility", False),
@@ -267,7 +90,8 @@ _DISPATCH = {
     "web_login": lambda m, a: m.web.login(url=a.get("url", ""), app=a.get("app", "Google Chrome")),
     "web_snapshot": lambda m, a: m.web.snapshot(),
     "web_screenshot": lambda m, a: m.web.screenshot(),
-    "web_act": lambda m, a: m.web.act(a.get("actions", [])),
+    "web_act": lambda m, a: m.web.act(a.get("actions", []), detailed=a.get("detailed", False),
+                                     postcondition=a.get("postcondition")),
     "web_restart": lambda m, a: m.web.restart(url=a.get("url", ""), app=a.get("app", "Google Chrome")),
     "web_tabs": lambda m, a: m.web.tabs(),
     "web_switch_tab": lambda m, a: m.web.switch_tab(a["index"]),
@@ -285,6 +109,12 @@ _DISPATCH = {
     "applescript": lambda m, a: m.applescript(a["script"], confirm=a.get("confirm", False)),
 }
 
+
+_DISPATCH.update({
+    "app_target": lambda m, a: m.targets(**a),
+    "app_capabilities": lambda m, a: m.capabilities(**a),
+    "app_recover": lambda m, a: m.recover(**a),
+})
 
 def _set_simultaneous(mac, on):
     mac.simultaneous = bool(on)
@@ -334,24 +164,26 @@ def _dispatch_core(mac, name, args):
     fn = _DISPATCH.get(name)
     if fn is None:
         return f"unknown tool {name}", True
+    redact = getattr(mac, "_redact", lambda value: value)
     try:
-        return fn(mac, args or {}), False
+        from .tool_registry import validate_arguments
+        value = fn(mac, validate_arguments(name, args or {}))
+        return mac._redact(value) if hasattr(mac, "_redact") else value, False
     except ApprovalDenied as e:
-        return (f"REFUSED: {e} — the user declined; do not retry the identical action, "
-                "adapt or call notify_user"), False
+        return redact(f"REFUSED: {e} — do not retry the identical action; adapt or ask the user"), False
     except StaleRef:
         return "ref is stale — re-snapshot the app and use fresh refs", False
     except (WebNotOpen, AccessibilityNotGranted, HunchError) as e:
-        return str(e), False
+        return redact(str(e)), False
     except Exception as e:  # noqa: BLE001 — genuinely unexpected: flag it
-        return f"error: {e}", True
+        return redact(f"error: {e}"), True
 
 
 def _run_tool(mac, tool_use):
     """API-backend formatter: dispatch one tool_use block -> an anthropic tool_result dict
     (bytes become an anthropic-shaped image block)."""
     value, is_error = _dispatch_core(mac, tool_use.name, tool_use.input or {})
-    content = _img(value) if isinstance(value, bytes) else value
+    content = _img(value) if isinstance(value, bytes) else (json.dumps(value) if isinstance(value, dict) else value)
     out = {"type": "tool_result", "tool_use_id": tool_use.id, "content": content}
     if is_error:
         out["is_error"] = True
@@ -398,7 +230,7 @@ def _mcp_content(value, is_error):
         content = [{"type": "image", "data": base64.b64encode(value).decode(),
                     "mimeType": "image/png"}]
     else:
-        content = [{"type": "text", "text": str(value)}]
+        content = [{"type": "text", "text": json.dumps(value) if isinstance(value, dict) else str(value)}]
     return {"content": content, **({"is_error": True} if is_error else {})}
 
 
@@ -416,7 +248,7 @@ def _sdk_tools(mac):
         return handler
 
     return [tool(t["name"], t["description"], t["input_schema"])(_make(t["name"]))
-            for t in AGENT_TOOLS]
+            for t in catalog_for(mac)]
 
 
 class SubscriptionBackend(Backend):
@@ -489,6 +321,8 @@ class SubscriptionBackend(Backend):
                 message="the Hunch agent only runs Hunch tools")
 
         system = HUNCH_PLAYBOOK + "\n" + AGENT_ADDENDUM
+        if hasattr(self._h, "session_summary"):
+            system += "\n" + self._h.session_summary()
         if system_suffix:
             system += "\n" + system_suffix
         opts = dict(
@@ -510,7 +344,7 @@ class SubscriptionBackend(Backend):
             opts["can_use_tool"] = self._permit
         else:
             opts["can_use_tool"] = _allow_hunch_only
-            opts["allowed_tools"] = [f"mcp__hunch__{t['name']}" for t in AGENT_TOOLS]
+            opts["allowed_tools"] = [f"mcp__hunch__{t['name']}" for t in catalog_for(self._h)]
         return sdk.ClaudeAgentOptions(**opts)
 
     # — the loop —
@@ -655,6 +489,8 @@ class ApiBackend(Backend):
     def _system(self, system_suffix):
         blocks = [{"type": "text", "text": HUNCH_PLAYBOOK + "\n" + AGENT_ADDENDUM,
                    "cache_control": {"type": "ephemeral"}}]
+        if hasattr(self._h, "session_summary"):
+            blocks.append({"type": "text", "text": self._h.session_summary()})
         if system_suffix:
             blocks.append({"type": "text", "text": system_suffix})
         return blocks
@@ -662,7 +498,7 @@ class ApiBackend(Backend):
     def _request(self, client, model, max_tokens, system, effort):
         """Provider seam: build kwargs + run one streamed turn, return the final Message."""
         kwargs = dict(model=model, max_tokens=max_tokens, system=system,
-                      tools=AGENT_TOOLS, messages=self.messages,
+                      tools=catalog_for(self._h), messages=self.messages,
                       thinking={"type": "adaptive"})
         if effort:
             kwargs["output_config"] = {"effort": effort}

--- a/src/hunch/ax_tree_mac.py
+++ b/src/hunch/ax_tree_mac.py
@@ -80,7 +80,7 @@ kAXWindowsAttribute = "AXWindows"
 
 
 def list_apps():
-    """List running GUI apps (activation policy == regular) as {name, pid}.
+    """List running regular and accessory apps as {name, pid}.
 
     NSWorkspace.runningApplications() is a KVO-updated array that only refreshes when a Cocoa run
     loop is spinning — in a long-lived non-Cocoa process (the MCP server) it stays FROZEN at first
@@ -98,12 +98,12 @@ def list_apps():
             if not pid or pid in seen:
                 continue
             app = NSRunningApplication.runningApplicationWithProcessIdentifier_(pid)
-            if app is not None and app.activationPolicy() == 0:
+            if app is not None and app.activationPolicy() in (0, 1):
                 seen[pid] = app.localizedName() or owner
     except Exception:
         pass
     for app in NSWorkspace.sharedWorkspace().runningApplications():
-        if app.activationPolicy() == 0 and app.processIdentifier() not in seen:
+        if app.activationPolicy() in (0, 1) and app.processIdentifier() not in seen:
             seen[app.processIdentifier()] = app.localizedName()
     return [{"name": n, "pid": p} for p, n in seen.items()]
 
@@ -113,6 +113,33 @@ def get_attr(element, attr):
     if err != 0:
         return None
     return value
+
+
+def read_attr(element, attr):
+    """Diagnostic reads preserve AX errors instead of conflating them with empty values."""
+    err, value = AXUIElementCopyAttributeValue(element, attr, None)
+    return {"error": int(err), "value": value if err == 0 else None}
+
+
+def discover_windows(ax_app):
+    windows, diagnostics = [], {}
+    for attr in (kAXFocusedWindowAttribute, kAXMainWindowAttribute,
+                 kAXWindowsAttribute, kAXChildrenAttribute):
+        result = read_attr(ax_app, attr)
+        diagnostics[attr] = result["error"]
+        value = result["value"]
+        values = (value or [])[:64] if attr in (kAXWindowsAttribute, kAXChildrenAttribute) else [value]
+        for element in values:
+            if element is None:
+                continue
+            if attr == kAXChildrenAttribute and get_attr(element, kAXRoleAttribute) != "AXWindow":
+                continue
+            existing = next((w for w in windows if w[0] == element), None)
+            if existing:
+                existing[1].append(attr)
+            else:
+                windows.append((element, [attr]))
+    return windows, diagnostics
 
 
 def get_actions(element):
@@ -430,7 +457,11 @@ def main():
     elif args.command == "dump":
         DEFAULT_MAX_NODES = args.max_nodes
         DEFAULT_MAX_CHILDREN = args.max_children
-        previous_front = NSWorkspace.sharedWorkspace().frontmostApplication() if args.activate else None
+        if args.activate:
+            from .local_mac import _frontmost
+            previous_front = NSRunningApplication.runningApplicationWithProcessIdentifier_(_frontmost()[1])
+        else:
+            previous_front = None
 
         if args.app_name is None:
             entries = dump_all_apps(args.max_depth, args.full, args.activate)

--- a/src/hunch/backends/codex.py
+++ b/src/hunch/backends/codex.py
@@ -14,9 +14,10 @@ Two architectural facts follow from Codex spawning its CLI runtime as a subproce
     identical, but caller-side live state (a simultaneous_mode toggle on THIS object)
     doesn't reach that process.
   • Host-owned permission routing (Agent(can_use_tool=...) / the app's Approve-Deny
-    popover) does NOT govern Codex's tool calls. The dangerous verbs are gated by the
-    hunch server's own click-to-approve dialogs instead. (Routing Codex's approval
-    protocol into the host callback is a future enhancement.)
+    popover) does NOT govern Codex's tool calls. Normally the dangerous verbs are gated
+    by the hunch server's own click-to-approve dialogs. An explicitly unattended Hunch
+    instance (confirm="off") propagates that choice to this private server and tells
+    Codex to approve its Hunch MCP tools without editing the user's global config.
 
 Auth is a `codex login` (ChatGPT/Codex subscription) session — set it up with
 hunch.provider("codex").login() or `codex login`. No API-key path is exposed.
@@ -94,9 +95,57 @@ class CodexBackend(Backend):
             "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
             "HOME": os.path.expanduser("~"),
         }
-        # deliberately DO NOT set HUNCH_NO_INTERNAL_GATE — we want the server to run its
-        # own click-to-approve dialogs, since host permission routing can't reach it here.
+        # The server is another process, so the caller's Gate object cannot reach it.
+        # Propagate only an explicit instance-level opt-out; normal sessions retain the
+        # server's click-to-approve gate and no persistent config is changed.
+        if self._unattended():
+            env["HUNCH_NO_INTERNAL_GATE"] = "1"
+        gate = getattr(self._h, "_gate", None)
+        if (self._permit is not None or callable(getattr(gate, "confirm", None))
+                or callable(getattr(gate, "_policy", None))
+                or getattr(self._h, "_notify_handler", None) is not None):
+            raise HunchError("Codex subprocess transport cannot preserve live host callbacks; "
+                             "use the in-process provider or serializable runtime policy")
+        computer = getattr(self._h, "_computer", None)
+        web = getattr(self._h, "web", None)
+        if computer is not None:
+            if getattr(self._h, "_secrets", None):
+                raise HunchError("Codex subprocess cannot inherit secret-output protection state; use the in-process provider")
+            if (getattr(computer.session, "_selected_window", None) is not None
+                    or getattr(web, "_computer", None) is not None):
+                raise HunchError("Codex subprocess cannot inherit a live native window/CDP session; "
+                                 "select it through the child tools or use the in-process provider")
+            env["HUNCH_RUNTIME_CONFIG"] = json.dumps({
+                "app": computer.app, "simultaneous": computer.simultaneous,
+                "background_only": self._h.background_only,
+                "allow_unrestricted_scripts": self._h.allow_unrestricted_scripts,
+                "allowed_web_origins": self._h.allowed_web_origins,
+                "app_id": self._h.app_id, "app_name": self._h.app_name,
+                "confirm": gate.confirm, "policy": gate._policy,
+                "cdp_port": None if getattr(web, "_auto_port", False) else web.port,
+                "cdp_profile": web.profile,
+                "snapshot_max_depth": computer.max_depth,
+                "snapshot_max_nodes": computer.max_nodes,
+                "notify": self._h._native_notifications,
+            })
         return sys.executable, ["-m", "hunch", "serve"], env
+
+    def _unattended(self):
+        """Whether this Hunch instance explicitly opted out of confirmations."""
+        return (getattr(getattr(self._h, "_gate", None), "confirm", None) == "off"
+                or bool(os.environ.get("HUNCH_NO_INTERNAL_GATE")))
+
+    def _trust_hunch_tools(self):
+        """Whether Codex may call this private Hunch server without per-call prompts.
+
+        The server's own content-aware gates remain active unless the whole Hunch
+        instance is explicitly unattended.  Learning sessions use this distinction so
+        read-only observations do not prompt repeatedly while shared-input and
+        destructive paths still require Hunch approval.
+        """
+        return self._unattended() or bool(
+            getattr(self._h, "_trust_private_hunch_tools", False)
+        )
 
     def _config_overrides(self):
         """Codex `-c key=value` config overrides registering the hunch MCP server, as the
@@ -107,13 +156,20 @@ class CodexBackend(Backend):
               f"mcp_servers.hunch.args={json.dumps(args)}"]
         for k, v in env.items():
             ov.append(f"mcp_servers.hunch.env.{k}={json.dumps(v)}")
+        if self._trust_hunch_tools():
+            # This governs Codex's own MCP approval UI. It is intentionally scoped to
+            # the private Hunch server rather than setting global approval_policy=never,
+            # which would also auto-approve unrelated shell and connector operations.
+            ov.append('mcp_servers.hunch.default_tools_approval_mode="approve"')
         return tuple(ov)
 
     # ── the playbook, delivered as Codex developer instructions ──────────────────
     def _instructions(self):
         from ..playbook import HUNCH_PLAYBOOK
         from ..agent import AGENT_ADDENDUM
-        return _PREAMBLE + HUNCH_PLAYBOOK + "\n" + AGENT_ADDENDUM
+        preamble = _PREAMBLE
+        summary = self._h.session_summary() if hasattr(self._h, "session_summary") else ""
+        return preamble + HUNCH_PLAYBOOK + "\n" + AGENT_ADDENDUM + "\n" + summary + "\n" + getattr(self, "_system_suffix", "")
 
     def _working_dir(self):
         """A private cwd for the Codex thread, so it never touches the user's project dir."""
@@ -164,7 +220,7 @@ class CodexBackend(Backend):
         if itype == "mcpToolCall":
             result = getattr(root, "result", None)
             if result is not None:
-                emit("tool_result", cls._result_text(result)[:200])
+                emit("tool_result", cls._result_text(result))
             return ""
         if itype == "agentMessage":
             text = (getattr(root, "text", "") or "").strip()
@@ -190,9 +246,16 @@ class CodexBackend(Backend):
         playbook as developer instructions. The one place the SDK's client surface is
         used; override in tests."""
         import openai_codex as oc
+        overrides = self._config_overrides()
+        if self._codex is not None and getattr(self, "_runtime_overrides", overrides) != overrides:
+            raise HunchError("runtime settings changed after Codex child creation; reset the agent first")
         if self._codex is None:
             # Relies on the user's `codex login` session (no API-key path).
-            self._codex = oc.Codex(config=oc.CodexConfig(config_overrides=self._config_overrides()))
+            config = {"config_overrides": overrides}
+            self._runtime_overrides = overrides
+            if os.environ.get("HUNCH_CODEX_BIN"):
+                config["codex_bin"] = os.environ["HUNCH_CODEX_BIN"]
+            self._codex = oc.Codex(config=oc.CodexConfig(**config))
         if self._thread is None:
             kwargs = dict(cwd=cwd, developer_instructions=self._instructions(),
                           sandbox=oc.Sandbox.workspace_write)
@@ -262,6 +325,9 @@ class CodexBackend(Backend):
         # from a `hunch.provider("codex").login()` / `codex login`. If nothing is authorized,
         # the SDK raises and we translate it into a login hint below.
         emit = on_event or (lambda kind, data: None)
+        if getattr(self, "_system_suffix", "") != system_suffix:
+            self._thread = None
+        self._system_suffix = system_suffix
         model = model or self.default_model
         cwd = self._working_dir()
 

--- a/src/hunch/capabilities.py
+++ b/src/hunch/capabilities.py
@@ -1,0 +1,144 @@
+"""Bounded observations and explicit recovery for a caller-owned Hunch session."""
+import re
+import time
+import uuid
+
+from .errors import ApprovalDenied, HunchError
+from .targets import TargetRegistry, process_key
+
+
+class Capabilities:
+    def __init__(self, owner):
+        self.owner = owner
+        self.registry = TargetRegistry()
+        self.plans = {}
+        self.history = []
+
+    def targets(self, app="", window="", select=False, inventory="running"):
+        if inventory == "installed":
+            if select or window:
+                raise HunchError("installed inventory cannot select a running window; use inventory='running'")
+            from .targets import installed_apps
+            return installed_apps(app)
+        if inventory != "running":
+            raise HunchError("inventory must be running or installed")
+        from . import local_mac as native
+        apps = [{**a, **native._running_identity(a["pid"])} for a in native.ax.list_apps()]
+        if not app:
+            return {"running": apps, "scope": "running applications; not installed inventory"}
+        from .targets import select_running
+        identity = native._resolve_app(app) if app.startswith("pid:") else select_running(app, apps)
+        if not identity:
+            return {"status": "blocked", "reason": "no matching running application", "app": app}
+        root = native.AXUIElementCreateApplication(identity["pid"])
+        observations, errors = native.ax.discover_windows(root)
+        windows = self.registry.bind(identity, observations)
+        if select:
+            selected = self.registry.window(window) if window else None
+            session = self.owner._computer.session
+            session._invalidate_refs()
+            session._selected_window = (process_key(identity), selected.element) if selected else None
+            self.owner._computer.app = f"pid:{identity['pid']}"
+            self.owner._aimed_app = self.owner._computer.app
+        return {"status": "available" if windows else "unavailable_in_current_state",
+                "target": identity, "generation": self.registry.generation,
+                "trusted": bool(native.AXIsProcessTrusted()), "ax_errors": errors,
+                "windows": [{"handle": w.handle, "provenance": w.provenance,
+                             "title": str(native.ax.get_attr(w.element, "AXTitle") or "")[:200]}
+                            for w in windows], "bounded": True, "window_limit": 64}
+
+    def inspect(self, app, operation="observe"):
+        from . import local_mac as native
+        result = self.targets(app)
+        if "target" not in result:
+            return result
+        identity = result["target"]
+        result.update(operation=operation, mechanism="ax", effect_verified=False,
+                      background_tested=False, observed_at=time.time(), recoveries=[])
+        # Available windows do not establish coverage of arbitrary user operations.
+        result["operation_status"] = "unknown"
+        if not result["trusted"]:
+            result["status"] = "permission_denied"
+        command = native._proc_cmdline(identity["pid"])
+        port = re.search(r"(?:^|\s)--remote-debugging-port=(\d+)(?:\s|$)", command)
+        if port:
+            result["recoveries"].append(self._plan(identity, operation, "attach_cdp", port=int(port[1])))
+        embedded = native._embedded_chromium(identity["pid"])
+        if embedded and result["trusted"]:
+            result["recoveries"].append(self._plan(identity, operation, "enable_ax"))
+            result["recoveries"].append(self._plan(identity, operation, "restart_ax"))
+        if embedded and not port:
+            result["recoveries"].append(self._plan(identity, operation, "restart_debug"))
+        result["history"] = [h for h in self.history if h["target"] == process_key(identity)][-8:]
+        attempted = {h["action"] for h in result["history"]}
+        result["recoveries"] = [p for p in result["recoveries"] if p["action"] != "enable_ax" or "enable_ax" not in attempted]
+        return result
+
+    def _constraints(self):
+        return (self.owner.background_only, self.owner.simultaneous,
+                self.owner._computer.app, getattr(self.owner._computer.session, "_selected_window", None))
+
+    def _plan(self, identity, operation, action, **options):
+        now = time.monotonic()
+        self.plans = {k: p for k, p in self.plans.items() if p["expires"] > now}
+        if len(self.plans) >= 64:
+            self.plans.pop(next(iter(self.plans)))
+        plan_id = uuid.uuid4().hex
+        plan = dict(target=dict(identity), operation=operation, action=action, options=options,
+                    expires=now + 120, constraints=self._constraints())
+        self.plans[plan_id] = plan
+        return {"plan_id": plan_id, "action": action, "expires_in_seconds": 120,
+                "process_restart": action.startswith("restart"),
+                "profile": "preserve verified profile; refuse unknown custom profile" if action.startswith("restart") else "unchanged"}
+
+    def recover(self, plan_id, target_id=""):
+        from . import local_mac as native
+        plan = self.plans.pop(plan_id, None)
+        if not plan or plan["expires"] <= time.monotonic():
+            raise HunchError("recovery plan expired or was already attempted; inspect capabilities again")
+        identity = plan["target"]
+        if (process_key(native._running_identity(identity["pid"])) != process_key(identity)
+                or self._constraints() != plan["constraints"]):
+            raise HunchError("recovery target or host constraints changed; inspect capabilities again")
+        action = plan["action"]
+        result = dict(status="performed_unverified", target=process_key(identity),
+                      action=action, operation=plan["operation"], disturbances={})
+        if action.startswith("restart"):
+            gate = self.owner._gate
+            if gate.enabled("app_to_front") and not gate.confirm_dialog(
+                    f"Restart {identity['name']} gracefully for {action}? Unsaved work may need attention.",
+                    category="app_lifecycle", detail=identity.get("path", ""), screen_approval=False):
+                raise ApprovalDenied("recovery restart was not authorized")
+        try:
+            if action == "enable_ax":
+                native._enable_manual_ax(native.AXUIElementCreateApplication(identity["pid"]))
+                result["evidence"] = self.targets(f"pid:{identity['pid']}")
+            elif action == "attach_cdp":
+                result["evidence"] = self.owner.web.attach(identity.get("path") or identity["name"],
+                                                          plan["options"]["port"], target_id,
+                                                          expected_identity=identity)
+            elif action in ("restart_ax", "restart_debug"):
+                port = None
+                if action == "restart_debug":
+                    import socket
+                    with socket.socket() as listener:
+                        listener.bind(("127.0.0.1", 0))
+                        port = listener.getsockname()[1]
+                message = native.launch_app(f"pid:{identity['pid']}",
+                                            force_accessibility=action == "restart_ax", background=True,
+                                            debugging_port=port)
+                result["evidence"] = message
+                result["disturbances"] = {"restart_requested": 1}
+                if message.startswith(("REFUSED:", "failed")):
+                    result["status"] = "blocked"
+                elif port:
+                    result["evidence"] = self.owner.web.attach(identity["path"], port, target_id)
+            else:
+                raise HunchError("unknown recovery action")
+        except Exception as error:
+            result.update(status="blocked", evidence=str(error))
+        if isinstance(result.get("evidence"), dict) and result["evidence"].get("status") == "blocked":
+            result["status"] = "blocked"
+        self.history.append({k: result[k] for k in ("target", "action", "status")})
+        self.history = self.history[-64:]
+        return result

--- a/src/hunch/cdp.py
+++ b/src/hunch/cdp.py
@@ -1,11 +1,9 @@
 """Hunch CDP backend — drive Chromium browsers and Electron apps FOCUS-FREE.
 
-Chromium/Electron apps expose the Chrome DevTools Protocol: launch with
---remote-debugging-port and you can read the page's accessibility tree AND
-inject clicks/keys straight into the renderer — no OS cursor, no window focus.
-That's what makes true simultaneous use work for the whole Chromium/Electron
-category (Chrome, Arc, Discord, Slack, Spotify, VS Code, ...), unlike AX which
-needs the app frontmost.
+Supported Chromium/Electron launches expose the Chrome DevTools Protocol.
+A verified endpoint provides renderer accessibility semantics, DOM references,
+and renderer-local input without moving the OS cursor. Native AX can also work
+in the background; coverage depends on the operation and current app state.
 
 Same snapshot/act/handle contract as local_mac.LocalComputer, so it drops into
 the same agent loop.
@@ -174,8 +172,8 @@ def _title_matches(title, path):
 def _pick_workbench(pages, folder=None):
     """From an editor's page targets, choose the real editor window: a workbench.html target whose
     title is NOT a side panel (Cursor's 'Cursor Agents', etc.). Returns None if none qualify yet —
-    the workbench target can lag the side panel at startup, so callers poll on this (and fall back
-    to pages[0] only after the timeout).
+    the workbench target can lag the side panel at startup, so callers poll on this.
+    Ambiguous windows require explicit target selection.
 
     With `folder`, a window whose title names that folder WINS. One editor instance commonly has
     several windows open (and restores the previous session's on launch), so 'the first workbench'
@@ -186,8 +184,8 @@ def _pick_workbench(pages, folder=None):
     if folder:
         hit = [p for p in main if _title_matches(p.get("title"), folder)]
         if hit:
-            return hit[0]
-    return (main or [None])[0]
+            return hit[0] if len(hit) == 1 else None
+    return main[0] if len(main) == 1 else None
 
 
 def open_folder_in_editor(app, profile, folder, background=True):
@@ -208,96 +206,163 @@ def _wait_for_port(port, timeout=15):
     end = time.time() + timeout
     while time.time() < end:
         try:
-            urllib.request.urlopen(f"http://localhost:{port}/json/version", timeout=2).read()
+            urllib.request.urlopen(f"http://127.0.0.1:{port}/json/version", timeout=2).read()
             return True
         except Exception:
             time.sleep(0.5)
     raise RuntimeError(f"debug port {port} did not open within {timeout}s")
 
 
-def _clear_singleton(data_dir):
-    """Remove stale Chrome Singleton* lock files that a hard-killed instance leaves behind —
-    they otherwise make a relaunch hand off to the dead lock-holder instead of binding the
-    debug port (the intermittent 'CDP port never opened' failure)."""
-    for f in ("SingletonLock", "SingletonSocket", "SingletonCookie"):
-        try:
-            os.remove(os.path.join(data_dir, f))
-        except OSError:
-            pass
+_OWNED_ENDPOINTS = {}
+
+
+def _endpoint_listeners(port):
+    result = subprocess.run(["lsof", "-nP", "-FpdRn", f"-iTCP:{int(port)}", "-sTCP:LISTEN"],
+                            capture_output=True, text=True, timeout=3)
+    listeners = {}
+    current = None
+    for line in result.stdout.splitlines():
+        if line.startswith("p"):
+            current = listeners.setdefault(int(line[1:]), {"parent": None, "sockets": set()})
+        elif current is not None and line.startswith("R"):
+            current["parent"] = int(line[1:])
+        elif current is not None and line.startswith("d"):
+            current["sockets"].add(line[1:])
+    if result.returncode:
+        return {}
+    return listeners
+
+
+def _endpoint_owner(listeners):
+    if len(listeners) == 1:
+        return next(iter(listeners))
+    # A forked helper can retain the parent's listening FD. Accept only the same
+    # kernel socket and an unbroken ancestry chain among its holders; names and
+    # matching ports alone cannot distinguish independent listeners.
+    sockets = [entry["sockets"] for entry in listeners.values()]
+    if not sockets or len(sockets[0]) != 1 or any(s != sockets[0] for s in sockets):
+        return None
+    socket_id = next(iter(sockets[0]))
+    if not re.fullmatch(r"0x[0-9a-fA-F]+", socket_id) or int(socket_id, 16) == 0:
+        return None
+    roots = [pid for pid, entry in listeners.items() if entry["parent"] not in listeners]
+    if len(roots) != 1:
+        return None
+    root = roots[0]
+    for pid in listeners:
+        seen = set()
+        while pid != root:
+            if pid in seen or pid not in listeners:
+                return None
+            seen.add(pid)
+            pid = listeners[pid]["parent"]
+    return root
+
+
+def endpoint_identity(port):
+    """Resolve the listening application, including verified inherited sockets."""
+    from .local_mac import _running_identity
+    from .targets import process_key
+    listeners = _endpoint_listeners(port)
+    pid = _endpoint_owner(listeners)
+    if pid is None:
+        raise RuntimeError(f"cannot verify one owning process for CDP port {port}")
+    identity = _running_identity(pid)
+    if not identity:
+        raise RuntimeError(f"CDP port {port} owner has no application identity")
+    if len(listeners) > 1:
+        if (_endpoint_listeners(port) != listeners
+                or process_key(_running_identity(pid) or {}) != process_key(identity)):
+            raise RuntimeError(f"CDP port {port} ownership changed during verification; retry attachment")
+    return identity
+
+
+def _app_path(app):
+    from AppKit import NSWorkspace
+    if os.path.isabs(app):
+        return os.path.realpath(app)
+    path = NSWorkspace.sharedWorkspace().fullPathForApplication_(app)
+    if not path:
+        raise RuntimeError(f"cannot resolve installed application {app!r}")
+    return os.path.realpath(str(path))
+
+
+def verify_endpoint(port, app):
+    identity = endpoint_identity(port)
+    if os.path.realpath(identity.get("path", "")) != _app_path(_resolve_app(app)):
+        raise RuntimeError(f"CDP port {port} belongs to {identity.get('path')}, not {app}")
+    return identity
 
 
 def launch_chromium(app_name, port, url=None, background=True, isolated=False, profile=None,
-                    editor=False):
-    """Launch a Chromium/Electron app with CDP enabled.
-      isolated=True  -> a throwaway sandbox profile (no logins).
-      otherwise      -> a persistent, DEDICATED Hunch profile (HUNCH_PROFILE, or `profile`)
-                        that the user signs into once and Hunch reuses focus-free.
-    We never touch the app's real/default profile: Chrome 136+ won't open the debug port
-    there, so killing the user's real browser (the old behaviour) gained nothing and lost
-    their tabs. Verifies the port actually binds before returning."""
+                    editor=False, allowed_origins=(), owner=None):
+    """Launch a dedicated instance; reuse only a verified, compatible owned endpoint."""
+    from .targets import process_key
+    if url and not editor:
+        from .destinations import navigation_refusal
+        refusal = navigation_refusal(url, allowed_origins)
+        if refusal:
+            raise RuntimeError(refusal)
     app = _resolve_app(app_name)
-    # Already listening? Reuse it rather than spawning a duplicate that fights the profile lock.
     try:
-        urllib.request.urlopen(f"http://localhost:{port}/json/version", timeout=1).read()
-        return f"reusing CDP instance already on :{port}"
+        urllib.request.urlopen(f"http://127.0.0.1:{port}/json/version", timeout=1).read()
+        listening = True
     except Exception:
-        pass
-    data_dir = tempfile.mkdtemp(prefix='hunch_cdp_') if isolated else (profile or HUNCH_PROFILE)
+        listening = False
+    if listening:
+        identity = verify_endpoint(port, app)
+        owned = _OWNED_ENDPOINTS.get(port)
+        if (not owned or owned.get("owner") is not owner or process_key(identity) != process_key(owned["identity"])
+                or isolated or owned["profile"] != os.path.realpath(profile or HUNCH_PROFILE)):
+            raise RuntimeError(f"CDP port {port} is already in use; explicitly attach or select a free port")
+        return f"reusing verified CDP instance on :{port}"
+    data_dir = tempfile.mkdtemp(prefix="hunch_cdp_", dir="/private/tmp") if isolated else os.path.realpath(profile or HUNCH_PROFILE)
+    # Leave room for the editor's versioned socket basename (macOS limit: 103 bytes).
+    if editor and len(os.fsencode(data_dir)) > 70:
+        raise RuntimeError("editor profile path is too long for macOS IPC; choose a shorter cdp_profile")
     os.makedirs(data_dir, exist_ok=True)
-    args = [f"--remote-debugging-port={port}", "--remote-allow-origins=*",
+    args = [f"--remote-debugging-port={port}", "--remote-debugging-address=127.0.0.1",
             f"--user-data-dir={data_dir}", "--no-first-run", "--no-default-browser-check",
-            # Hunch drives this window in the BACKGROUND (open -g). Without these, Chromium
-            # throttles hidden pages (timers clamped, rAF paused, occluded windows stop
-            # compositing) and JS-rendered sites never finish loading. Same trio Playwright/
-            # Puppeteer use; the window still stays behind everything.
-            "--disable-background-timer-throttling",
-            "--disable-backgrounding-occluded-windows",
+            "--disable-background-timer-throttling", "--disable-backgrounding-occluded-windows",
             "--disable-renderer-backgrounding"]
     if url:
         args.append(url)
-    cmd = ["open"] + (["-g"] if background else []) + ["-na", app, "--args"] + args
-
-    last_err = ""
-    for attempt in (1, 2):
-        proc = subprocess.run(cmd, capture_output=True, text=True)
-        # `open` prints "Unable to find application named 'X'" and returns non-zero when the
-        # app name is wrong — surface THAT clearly instead of a misleading debug-port timeout.
-        if proc.returncode != 0 or "unable to find application" in (proc.stderr or "").lower():
-            if editor:
-                raise RuntimeError(
-                    f"no editor named {app_name!r} on this Mac ({(proc.stderr or '').strip() or 'not found'}). "
-                    f"Supported editors: Cursor, Visual Studio Code, VSCodium, Windsurf.")
-            raise RuntimeError(
-                f"no browser named {app_name!r} on this Mac ({(proc.stderr or '').strip() or 'not found'}). "
-                f"web_open drives a Chromium BROWSER (or Electron app) — pass a browser like "
-                f"'Google Chrome' and open a website (Gmail etc.) via the url argument, not as the app.")
-        try:
-            _wait_for_port(port, timeout=15)
-            return (f"launched {app} on :{port} (profile={'sandbox' if isolated else data_dir})"
-                    + (" background" if background else " foreground")
-                    + (" (self-healed)" if attempt == 2 else ""))
-        except RuntimeError as e:
-            last_err = str(e)
-            # SELF-HEAL: the profile is almost certainly held by a stale/locked instance (a
-            # prior hard-kill leaves Singleton locks, so the relaunch hands off to a dead
-            # holder and never binds the port). Quit that instance, clear the locks, retry
-            # ONCE — so callers never punt "please quit Chrome yourself" back to the user.
-            quit_cdp(port)
-            subprocess.run(["pkill", "-f", f"--user-data-dir={data_dir}"], check=False)
-            if not isolated:
-                _clear_singleton(data_dir)
-            time.sleep(2)
-    raise RuntimeError(
-        f"couldn't get {app} to expose its debug port on :{port} even after quitting and "
-        f"relaunching it fresh. {last_err}")
+    command = ["open"] + (["-g"] if background else []) + ["-na", app, "--args"] + args
+    result = subprocess.run(command, capture_output=True, text=True)
+    if result.returncode:
+        raise RuntimeError(f"failed to launch {app}: {result.stderr.strip()}")
+    _wait_for_port(port, timeout=15)
+    identity = verify_endpoint(port, app)
+    from .local_mac import _proc_cmdline
+    command_line = _proc_cmdline(identity["pid"])
+    if f"--user-data-dir={data_dir}" not in command_line:
+        raise RuntimeError("launched endpoint did not preserve the requested profile; ownership unverified")
+    _OWNED_ENDPOINTS[port] = {"identity": identity, "profile": data_dir, "app": app,
+                              "isolated": isolated, "owner": owner}
+    return f"launched verified {app} on :{port} (profile={data_dir})"
 
 
-def quit_cdp(port):
-    """Quit ONLY the CDP-controlled browser instance — the one launched with this debug
-    port. The user's normal browser has no such flag, so it's never touched. Used to
-    recover from a stuck/blank page by relaunching fresh (same profile keeps the login)."""
-    subprocess.run(["pkill", "-f", f"remote-debugging-port={port}"], check=False)
-    time.sleep(2)
+def quit_cdp(port, *, owner=None):
+    """Gracefully quit a process this runtime launched, after rechecking ownership."""
+    from AppKit import NSRunningApplication
+    from .targets import process_key
+    from .local_mac import _process_alive
+    owned = _OWNED_ENDPOINTS.get(port)
+    if not owned or owned.get("owner") is not owner:
+        raise RuntimeError(f"cannot quit unowned CDP endpoint :{port}; attach or inspect it first")
+    identity = endpoint_identity(port)
+    if process_key(identity) != process_key(owned["identity"]):
+        raise RuntimeError("CDP ownership changed; refusing to quit")
+    app = NSRunningApplication.runningApplicationWithProcessIdentifier_(identity["pid"])
+    if app is None:
+        raise RuntimeError("CDP owning process disappeared")
+    app.terminate()
+    deadline = time.monotonic() + 6
+    while _process_alive(identity["pid"]) and time.monotonic() < deadline:
+        time.sleep(0.2)
+    if _process_alive(identity["pid"]):
+        raise RuntimeError("CDP application did not quit gracefully; resolve its save/confirmation prompt")
+    del _OWNED_ENDPOINTS[port]
     return f"quit CDP instance on :{port}"
 
 
@@ -316,24 +381,35 @@ class CDPSession:
         self._known_targets = set()  # target ids we've already seen (to detect NEW tabs)
         self.editor = False         # driving an Electron editor (multi-window) vs a browser
         self.pinned = None          # editor: the folder this session is deliberately bound to
+        self.pinned_app = False
+        self.allowed_origins = ()
 
     def _list_page_targets(self):
         """All page (tab/window) targets on this debug port. Chrome reports the most recently
         created/active page first."""
         try:
-            targets = json.load(urllib.request.urlopen(f"http://localhost:{self.port}/json", timeout=3))
+            targets = json.load(urllib.request.urlopen(f"http://127.0.0.1:{self.port}/json", timeout=3))
         except Exception:
             return []
         return [t for t in targets if t.get("type") == "page" and t.get("webSocketDebuggerUrl")]
 
     def _open_ws(self, page):
         """(Re)bind this session's websocket to a specific page target and enable its CDP domains."""
+        from urllib.parse import urlsplit
+        address = urlsplit(page["webSocketDebuggerUrl"])
+        if (address.scheme != "ws" or address.hostname not in ("127.0.0.1", "localhost", "::1")
+                or address.port != self.port or address.username or address.password):
+            raise RuntimeError("refusing CDP websocket outside the verified local endpoint")
         if self.ws:
             try:
                 self.ws.close()
             except Exception:
                 pass
-        self.ws = websocket.create_connection(page["webSocketDebuggerUrl"], timeout=15, max_size=None)
+        self.registry.clear()
+        self._observed_document = None
+        self._last_screenshot_scale = None
+        self.ws = websocket.create_connection(page["webSocketDebuggerUrl"], timeout=15,
+                                              max_size=None, suppress_origin=True)
         self.target_id = page.get("id")
         self._id = 0
         for d in ("DOM", "Accessibility", "Runtime", "Page"):
@@ -352,9 +428,9 @@ class CDPSession:
         end = time.time() + timeout
         pages = []
         self.editor = bool(editor)
-        while time.time() < end and not (pages if not editor else _pick_workbench(pages)):
+        while time.time() < end and not (pages if not editor else _pick_workbench(pages, folder)):
             pages = self._list_page_targets()
-            if not pages or (editor and not _pick_workbench(pages)):
+            if not pages or (editor and not _pick_workbench(pages, folder)):
                 time.sleep(0.5)
         if not pages:
             raise RuntimeError(f"no CDP page target on :{self.port} — is the app launched with --remote-debugging-port?")
@@ -362,7 +438,10 @@ class CDPSession:
         # editor window AND side panels like Cursor's "Agents" (title 'Cursor Agents'). They differ
         # only by title, so bind the editor window (has the tree + terminal), not a side panel —
         # and, when a folder was asked for, the window actually holding it.
-        target = _pick_workbench(pages, folder) or pages[0] if editor else pages[0]
+        target = _pick_workbench(pages, folder) if editor else (pages[0] if len(pages) == 1 else None)
+        if target is None:
+            raise RuntimeError("multiple or unmatched CDP targets; explicitly select a target ID: "
+                               + "; ".join(f"{p.get('id')}: {p.get('title')}" for p in pages))
         self._open_ws(target)
         self._known_targets = {p.get("id") for p in pages}
         return self
@@ -374,30 +453,37 @@ class CDPSession:
         multi-target handling; returns True if it switched."""
         pages = self._list_page_targets()
         if not pages:
-            return False
+            self.registry.clear()
+            self._last_screenshot_scale = None
+            raise RuntimeError("no CDP page targets available; inspect the endpoint again")
         ids = {p.get("id") for p in pages}
+        if self.pinned_app:
+            if self.target_id not in ids:
+                self.registry.clear()
+                raise RuntimeError("selected app renderer closed; explicitly select another target")
+            self._known_targets = ids
+            return False
         if self.editor:
             # An editor is MULTI-WINDOW: a new target is another window or a side panel the user
             # (or the editor itself) opened — never a page we navigated to. Auto-following one
             # would silently move the session off the workspace we were told to drive, which is
             # exactly how a read of "the hunch window" came back with someone else's project.
-            # Only re-bind if our own window is gone.
+            # A replacement with the same title is still a different target.
             self._known_targets = ids
             if self.target_id in ids:
                 return False
-            hit = _pick_workbench(pages, self.pinned)
-            if hit is None:
-                return False
-            self._open_ws(hit)
-            return True
-        new_pages = [p for p in pages if p.get("id") not in self._known_targets]
+            self.registry.clear()
+            self._last_screenshot_scale = None
+            raise RuntimeError("selected editor window closed; explicitly select another target")
+        new_pages = [p for p in pages if p.get("id") not in self._known_targets
+                     and p.get("openerId") == self.target_id]
         switched = False
-        if new_pages:
+        if len(new_pages) == 1:
             self._open_ws(new_pages[0])       # newest-first -> the tab that just opened
             switched = True
-        elif self.target_id not in ids:       # our tab was closed
-            self._open_ws(pages[0])
-            switched = True
+        elif self.target_id not in ids:
+            self.registry.clear()
+            raise RuntimeError("selected CDP target closed; explicitly select another target")
         self._known_targets = ids
         return switched
 
@@ -436,7 +522,7 @@ class CDPSession:
 
     def tabs(self):
         pages = self._list_page_targets()
-        return [{"index": i, "title": (p.get("title") or "")[:80], "url": (p.get("url") or "")[:120],
+        return [{"index": i, "id": p.get("id"), "title": (p.get("title") or "")[:80], "url": (p.get("url") or "")[:120],
                  "current": p.get("id") == self.target_id} for i, p in enumerate(pages)]
 
     def switch_tab(self, index):
@@ -460,7 +546,9 @@ class CDPSession:
                 if "error" in m:
                     raise RuntimeError(f"{method}: {m['error'].get('message')}")
                 return m.get("result", {})
-            # else: an event — ignore
+            if m.get("method") == "Page.frameNavigated" and not m.get("params", {}).get("frame", {}).get("parentId"):
+                self.registry.clear()
+                self._last_screenshot_scale = None
         raise RuntimeError(f"{method}: timed out")
 
     def _ref(self, backend_id):
@@ -468,6 +556,17 @@ class CDPSession:
         r = f"e{self._counter}"
         self.registry[r] = backend_id
         return r
+
+    def _document_identity(self):
+        frame = self._cmd("Page.getFrameTree").get("frameTree", {}).get("frame", {})
+        return self.target_id, frame.get("id"), frame.get("loaderId"), frame.get("url")
+
+    def validate_document(self):
+        expected = getattr(self, "_observed_document", None)
+        if expected is not None and self._document_identity() != expected:
+            self.registry.clear()
+            self._last_screenshot_scale = None
+            raise RuntimeError("CDP document changed; take a fresh snapshot before acting")
 
     def url(self):
         try:
@@ -484,8 +583,8 @@ class CDPSession:
     # ── perception ──────────────────────────────────────────────────────
     def snapshot(self, compact=True, max_nodes=1500):
         self._follow_new_tab()   # if a click/form opened a new tab, move onto it before reading
+        document = self._document_identity()
         self.registry = {}
-        self._counter = 0
         self.snapshot_count += 1
         nodes = self._cmd("Accessibility.getFullAXTree")["nodes"]
         by_id = {n["nodeId"]: n for n in nodes}
@@ -498,6 +597,10 @@ class CDPSession:
             lines.append(f"…tree truncated at {max_nodes} elements shown (+{budget['skipped']} "
                          "more) — interact/scroll to change the page, then web_snapshot again")
         text = "\n".join(lines)
+        if document != self._document_identity():
+            self.registry.clear()
+            raise RuntimeError("CDP document changed during observation; retry snapshot")
+        self._observed_document = document
         return text, {"est_tokens": round(len(text) / 3.5), "refs": len(self.registry), "url": self.url()}
 
     @staticmethod
@@ -738,6 +841,36 @@ class CDPSession:
                                                   "unmodifiedText": unmodified})
             self._cmd("Input.dispatchKeyEvent", {**base, "type": "keyUp"})
 
+    def fill_secret(self, ref, text, expected_url):
+        """Fill only a verified form input; never fall back to terminal/key events."""
+        from urllib.parse import urlsplit
+        parsed = urlsplit(expected_url)
+        expected_origin = f"{parsed.scheme}://{parsed.netloc}"
+        self.validate_document()
+        if ref:
+            backend = self.registry.get(ref)
+            if backend is None:
+                return False
+            obj = self._cmd("DOM.resolveNode", {"backendNodeId": backend}).get("object", {}).get("objectId")
+        else:
+            obj = self._cmd("Runtime.evaluate", {"expression": "document.activeElement"}).get("result", {}).get("objectId")
+        if not obj:
+            return False
+        result = self._cmd("Runtime.callFunctionOn", {
+            "objectId": obj, "arguments": [{"value": text}, {"value": expected_origin}],
+            "returnByValue": True,
+            "functionDeclaration": """function(value, origin) {
+              if (location.origin !== origin || !this.isConnected || this.disabled || this.readOnly
+                  || !this.matches('input,textarea') || this.closest('.xterm')
+                  || /^(file|checkbox|radio|button|submit|reset|image|hidden)$/.test(this.type)) return false;
+              const proto = this.tagName === 'TEXTAREA' ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+              Object.getOwnPropertyDescriptor(proto, 'value').set.call(this, value);
+              this.dispatchEvent(new Event('input', {bubbles:true}));
+              this.dispatchEvent(new Event('change', {bubbles:true}));
+              return this.value === value;
+            }"""})
+        return result.get("result", {}).get("value") is True
+
     def type_text(self, ref, text):
         """Fill a field, REPLACING its content. Works for text inputs, textareas, and native
         <select> dropdowns (matches an option by visible text/value). An xterm.js TERMINAL
@@ -776,13 +909,18 @@ class CDPSession:
         self._cmd("Input.insertText", {"text": text})
         return f"typed into {ref} (replaced)"
 
-    def fill_login(self, username, password):
+    def fill_login(self, username, password, expected_url=""):
         """Fill the visible login form's username + password fields. The values go STRAIGHT into
         the page over CDP and are NEVER returned — the caller (and thus the agent/LLM) only learns
         which fields were filled. Handles two-step logins by filling whatever visible fields exist
         (call again after advancing to the password step). Returns {'username_filled','password_filled'}."""
+        from urllib.parse import urlsplit
+        parsed = urlsplit(expected_url)
+        expected_origin = f"{parsed.scheme}://{parsed.netloc}" if expected_url else ""
+        self.validate_document()
         js = (
-            "(function(u,p){"
+            "(function(u,p,origin){"
+            "if(!origin || location.origin!==origin) return JSON.stringify({user:false,pass:false});"
             "function vis(el){var r=el.getBoundingClientRect();return r.width>0&&r.height>0&&el.offsetParent!==null;}"
             "function setVal(el,val){var proto=el.tagName==='TEXTAREA'?window.HTMLTextAreaElement.prototype:window.HTMLInputElement.prototype;"
             "var setter=Object.getOwnPropertyDescriptor(proto,'value').set;el.focus();setter.call(el,val);"
@@ -794,9 +932,9 @@ class CDPSession:
             "if(!user)user=[].slice.call(document.querySelectorAll("
             "'input[type=email],input[autocomplete=username],input[name*=email i],input[name*=user i],"
             "input[id*=email i],input[id*=user i],input[type=text],input[type=tel]')).filter(vis)[0]||null;"
-            "var du=false,dp=false;if(user&&u){setVal(user,u);du=true;}if(pass&&p){setVal(pass,p);dp=true;}"
+            "var du=false,dp=false;if(user&&u){setVal(user,u);du=user.value===u;}if(pass&&p){setVal(pass,p);dp=pass.value===p;}"
             "return JSON.stringify({user:du,pass:dp});})("
-            + json.dumps(username or "") + "," + json.dumps(password or "") + ")"
+            + json.dumps(username or "") + "," + json.dumps(password or "") + "," + json.dumps(expected_origin) + ")"
         )
         try:
             res = self._cmd("Runtime.evaluate", {"expression": js, "returnByValue": True})
@@ -860,24 +998,15 @@ class CDPSession:
         return ("accounts.google.com" in low) or ("/signin" in low) or ("sign in" in low)
 
     def navigate(self, url):
-        # SSRF + hallucination guards: block private/internal hosts before any fetch,
-        # then ensure the host actually resolves. Private check must come first – a
-        # private host *does* resolve (localhost -> 127.0.0.1) and would otherwise be fetched.
-        parsed = urllib.parse.urlparse(url)
-        host = parsed.hostname
-        if parsed.scheme and parsed.scheme.lower() not in ("http", "https"):
-            return (f"REFUSED: navigation to scheme '{parsed.scheme}' is blocked — only http/https "
-                    f"are allowed. If you need a file, use the filesystem tools.")
-        if host and _is_blocked_host(host):
-            return (f"REFUSED: navigation to private/internal host '{host}' is blocked (SSRF "
-                    f"protection). Navigate only to public http(s) hosts, or click a link by ref "
-                    f"instead of guessing a URL.")
-        if host and not _host_resolves(host):
-            return (f"'{url}' — host '{host}' does NOT resolve (DNS). If you constructed or guessed this "
-                    "URL, don't: go back to the page and CLICK the actual link (by ref) so its real "
-                    "href/redirect takes you there. Only navigate to URLs the user gave you or that you "
-                    "read from the page.")
-        self._cmd("Page.navigate", {"url": url})
+        from .destinations import navigation_refusal
+        refusal = navigation_refusal(url, self.allowed_origins)
+        if refusal:
+            return refusal
+        self.registry.clear()
+        self._last_screenshot_scale = None
+        result = self._cmd("Page.navigate", {"url": url})
+        if result.get("errorText"):
+            return f"REFUSED: navigation failed: {result['errorText']}"
         time.sleep(2)
         # A guessed PATH on a valid host (e.g. a16z.com/apply) resolves but often 404s. If the landed
         # page looks like a not-found, say so and steer back to exploring from the homepage.
@@ -942,31 +1071,9 @@ class CDPSession:
 
 
 # ── CDPComputer: the agent-facing wrapper (same tools/handle contract) ────────
-CDP_TOOLS = [
-    {"name": "snapshot",
-     "description": ("Look at the browser/Electron page as an accessibility tree — one element "
-                     "per line tagged [ref]. Act on elements by ref. All actions are focus-free "
-                     "(injected into the page), so they never disturb the user."),
-     "input_schema": {"type": "object", "properties": {}}},
-    {"name": "act",
-     "description": ("Execute one or more page actions in order, then get the updated tree. "
-                     "click (press an element by ref), click_xy/drag (act at coordinates from the "
-                     "latest screenshot, for canvas editors), type (fill a field by ref — REPLACES its "
-                     "content, fires real input/change events; also selects a native <select> "
-                     "dropdown option by its visible text, e.g. type 'January' into a month select), "
-                     "key (press a key like 'return'/'tab' with optional modifiers), navigate (go "
-                     "to a URL). Note: never try to click a native <select> and then its option — "
-                     "CDP can't open the OS dropdown; use type with the option text instead."),
-     "input_schema": {"type": "object", "properties": {"actions": {"type": "array", "items": {
-         "type": "object", "properties": {
-             "action": {"type": "string", "enum": ["click", "click_xy", "drag", "type", "key", "navigate"]},
-             "ref": {"type": "string"}, "text": {"type": "string"}, "key": {"type": "string"},
-             "modifiers": {"type": "array", "items": {"type": "string"}}, "url": {"type": "string"},
-             "x": {"type": "number"}, "y": {"type": "number"},
-             "from_x": {"type": "number"}, "from_y": {"type": "number"},
-             "to_x": {"type": "number"}, "to_y": {"type": "number"}},
-         "required": ["action"]}}}, "required": ["actions"]}},
-]
+from .tool_registry import BASE_TOOLS
+CDP_TOOLS = [{**tool, "name": tool["name"].removeprefix("web_")} for tool in BASE_TOOLS
+             if tool["name"] in {"web_snapshot", "web_act"}]
 
 
 class CDPComputer:
@@ -975,28 +1082,36 @@ class CDPComputer:
     but for the whole Chromium/Electron category, in the background."""
 
     def __init__(self, app, port=9333, url=None, isolated=False, background=True,
-                 connect=True, profile=None, editor=False):
+                 connect=True, profile=None, editor=False, allowed_origins=(), owner=None):
         self.app = app
         self.port = port
         self.editor = editor
         self.tools = CDP_TOOLS
         self.session = None
         self.launch_note = ""
+        self.identity = None
         if connect:
             self.launch_note = launch_chromium(app, port, url=url, background=background,
-                                               isolated=isolated, profile=profile, editor=editor)
+                                               isolated=isolated, profile=profile, editor=editor,
+                                               allowed_origins=allowed_origins, owner=owner)
             # editors expose several page targets — bind the workbench (holds the tree + terminal)
             self.session = CDPSession(port).connect(editor=editor,
                                                     folder=url if editor else None)
+            self.identity = _OWNED_ENDPOINTS[port]["identity"]
+            self.session.allowed_origins = allowed_origins
+            self.session.pinned_app = _resolve_app(app) not in _BROWSER_ALIASES.values()
 
     def snapshot(self):
         return self.session.snapshot()[0]
 
-    def act(self, actions):
+    def act(self, actions, detailed=False, postcondition=None):
+        from .results import action_receipt, validate_postcondition
+        validate_postcondition(postcondition)
         lines = []
         for a in actions:
             act = a.get("action")
             try:
+                self.session.validate_document()
                 if act == "click":
                     lines.append(self.session.click(a["ref"]))
                 elif act == "click_xy":
@@ -1010,13 +1125,37 @@ class CDPComputer:
                     lines.append(self.session.press_key(a["key"], a.get("modifiers")))
                 elif act == "navigate":
                     lines.append(self.session.navigate(a["url"]))
+                    break
                 else:
                     lines.append(f"unknown action {act}")
+                if lines and any(marker in lines[-1].lower() for marker in ("refused", "stale", "failed")):
+                    break
                 time.sleep(0.4)
             except Exception as e:  # noqa: BLE001
                 lines.append(f"error on {act}: {e}")
                 break
         time.sleep(0.6)
+        if detailed or postcondition is not None:
+            def read(ref, field):
+                self.session.validate_document()
+                backend = self.session.registry.get(ref)
+                if backend is None:
+                    raise ValueError("stale postcondition ref; observe the new document")
+                obj = self.session._cmd("DOM.resolveNode", {"backendNodeId": backend}).get("object", {}).get("objectId")
+                if not obj:
+                    raise ValueError("postcondition element unavailable")
+                expressions = {"value": "this.value", "title": "this.getAttribute('title')",
+                               "enabled": "!this.disabled", "selected": "this.selected ?? this.checked ?? this.getAttribute('aria-selected')",
+                               "expanded": "this.getAttribute('aria-expanded')"}
+                value = self.session._cmd("Runtime.callFunctionOn", {
+                    "objectId": obj, "functionDeclaration": "function(){ return " + expressions[field] + "; }",
+                    "returnByValue": True}).get("result", {})
+                if "value" not in value:
+                    raise ValueError("postcondition field unavailable")
+                return value["value"]
+            outcome = action_receipt(lines, len(actions), "cdp", {
+                "identity": self.identity, "renderer": self.session.target_id}, {}, postcondition, read)
+            return {**outcome, "observation": self.snapshot()}
         return "Executed:\n" + "\n".join(lines) + "\n\nScreen now:\n" + self.snapshot()
 
     def handle(self, tool_use):
@@ -1027,7 +1166,8 @@ class CDPComputer:
             if name == "snapshot":
                 content = self.snapshot()
             elif name == "act":
-                content = self.act(args["actions"])
+                content = self.act(args["actions"], detailed=args.get("detailed", False),
+                                   postcondition=args.get("postcondition"))
             else:
                 return {"type": "tool_result", "tool_use_id": tid, "content": f"unknown tool {name}", "is_error": True}
             return {"type": "tool_result", "tool_use_id": tid, "content": content}

--- a/src/hunch/cli.py
+++ b/src/hunch/cli.py
@@ -129,7 +129,7 @@ def cmd_creds(args):
         for name in names:
             kind = creds.kind_of(name)
             domains = creds.domains_of(name)
-            bound = ", ".join(domains) if domains else "any site (unbound)"
+            bound = ", ".join(domains) if domains else "unbound (automated fills disabled)"
             print(f"  {name}  [{kind}]  domains: {bound}")
         return 0
 
@@ -139,6 +139,14 @@ def cmd_creds(args):
             return 1
         creds.delete_credential(args.service)
         print(f"removed '{args.service}' from the Keychain.")
+        return 0
+
+    if args.creds_action == "bind":
+        if not creds.has(args.service):
+            print(f"no saved credential named {args.service!r}", file=sys.stderr)
+            return 1
+        creds.set_domains(args.service, args.domain)
+        print(f"bound {args.service!r} to {', '.join(creds.domains_of(args.service))}")
         return 0
 
     # add
@@ -159,12 +167,12 @@ def cmd_creds(args):
     domains = list(args.domain or [])
     if not domains:
         raw = input("Bind to domain(s)? (recommended — comma-separated, e.g. google.com; "
-                    "blank = usable on any site): ").strip()
+                    "blank = automated fills disabled): ").strip()
         domains = [d for d in (x.strip() for x in raw.split(",")) if d]
     creds.set_domains(service, domains)
-    bound = ", ".join(creds.domains_of(service)) or "any site (unbound)"
+    bound = ", ".join(creds.domains_of(service)) or "unbound (automated fills disabled)"
     print(f"saved '{service}' to the macOS Keychain. Fillable on: {bound}\n"
-          "The value never enters the model's context — agents fill it via "
+          "Fill results omit the value; known filled strings are redacted. Agents use "
           f"web_fill_{'secret' if args.secret else 'login'}('{service}').")
     return 0
 
@@ -421,7 +429,23 @@ def cmd_setup(args):
     return 0
 
 
+# ── probe ──────────────────────────────────────────────────────────────────────
+
+
+
+
+# ── experiment ─────────────────────────────────────────────────────────────────
+
+
+
+
 # ── main ───────────────────────────────────────────────────────────────────────
+
+
+
+
+
+
 
 
 def main(argv=None):
@@ -463,6 +487,9 @@ def main(argv=None):
     pa.add_argument("--domain", action="append",
                     help="domain(s) this credential may be filled on (repeatable)")
     csub.add_parser("list", help="list saved services (names/kinds/domains — never values)")
+    pb = csub.add_parser("bind", help="bind an existing credential without reading its secret")
+    pb.add_argument("service")
+    pb.add_argument("--domain", action="append", required=True)
     pr = csub.add_parser("remove", help="delete a saved credential")
     pr.add_argument("service")
     p.set_defaults(func=cmd_creds)

--- a/src/hunch/creds.py
+++ b/src/hunch/creds.py
@@ -20,8 +20,9 @@ store (the MCP server / `hunch creds` CLI). A namespace string (an app's id, e.g
 "com.acme.mailbot") -> that app's OWN Keychain service and metadata files under
 ~/.hunch/apps/<ns>/ — two apps built on the SDK can never see or fill each other's credentials.
 
-Note: set_credential passes the secret as a `security` argv, briefly visible to local `ps`. That's a
-local-only exposure (never reaches the LLM); moving it to a stdin/pty feed is a future hardening.
+Writes use Security.framework directly, so secrets do not appear in subprocess arguments.
+Known filled values are redacted from Hunch tool output; transformed app-rendered disclosures
+are not universally preventable. Screenshots are blocked in a session after a secret fill.
 """
 import json
 import os
@@ -87,9 +88,7 @@ def _write_kinds(kinds, ns=None):
 
 
 def _store_blob(name, blob, kind, ns=None):
-    subprocess.run(["security", "add-generic-password", "-U",
-                    "-s", _service(ns), "-a", name, "-w", blob],
-                   check=True, capture_output=True, text=True)
+    _store_keychain_blob(_service(ns), name, blob)
     names = _read_index(ns)
     if name not in names:
         names.append(name)
@@ -98,6 +97,38 @@ def _store_blob(name, blob, kind, ns=None):
     if kinds.get(name) != kind:
         kinds[name] = kind
         _write_kinds(kinds, ns)
+
+
+def _security_framework():
+    import ctypes
+    import objc
+    framework = ctypes.CDLL("/System/Library/Frameworks/Security.framework/Security")
+    def constant(name):
+        return objc.objc_object(c_void_p=ctypes.c_void_p.in_dll(framework, name).value)
+    return framework, constant
+
+
+def _store_keychain_blob(service, account, blob):
+    """Use Security.framework directly so secret material never appears in argv."""
+    import ctypes
+    import objc
+    from Foundation import NSDictionary, NSData
+    framework, constant = _security_framework()
+    query = {constant("kSecClass"): constant("kSecClassGenericPassword"),
+             constant("kSecAttrService"): service, constant("kSecAttrAccount"): account}
+    encoded = blob.encode("utf-8")
+    values = {constant("kSecValueData"): NSData.dataWithBytes_length_(encoded, len(encoded))}
+    query_object, values_object = NSDictionary.dictionaryWithDictionary_(query), NSDictionary.dictionaryWithDictionary_(values)
+    update = framework.SecItemUpdate
+    update.argtypes, update.restype = [ctypes.c_void_p, ctypes.c_void_p], ctypes.c_int32
+    status = update(objc.pyobjc_id(query_object), objc.pyobjc_id(values_object))
+    if status == -25300:  # errSecItemNotFound
+        item = NSDictionary.dictionaryWithDictionary_({**query, **values})
+        add = framework.SecItemAdd
+        add.argtypes, add.restype = [ctypes.c_void_p, ctypes.c_void_p], ctypes.c_int32
+        status = add(objc.pyobjc_id(item), None)
+    if status:
+        raise RuntimeError(f"Keychain write failed (OSStatus {status})")
 
 
 def _read_blob(name, ns=None):

--- a/src/hunch/destinations.py
+++ b/src/hunch/destinations.py
@@ -1,0 +1,26 @@
+"""Navigation request policy; this does not claim to isolate renderer network traffic."""
+from urllib.parse import urlsplit
+
+
+def origin(url):
+    parsed = urlsplit(url)
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    return parsed.scheme.lower(), (parsed.hostname or "").lower(), port
+
+
+def navigation_refusal(url, allowed_origins=()):
+    from .cdp import _host_resolves, _is_blocked_host
+    try:
+        parsed = urlsplit(url)
+        requested = origin(url)
+        if parsed.scheme not in ("http", "https") or not parsed.hostname or parsed.username or parsed.password:
+            return "REFUSED: navigation requires an absolute http(s) URL without embedded credentials"
+        if requested in {origin(value) for value in allowed_origins}:
+            return None
+        if _is_blocked_host(parsed.hostname):
+            return "REFUSED: private destination requires an explicit host allowed_web_origins entry"
+        if not _host_resolves(parsed.hostname):
+            return "REFUSED: destination host does not resolve"
+    except ValueError:
+        return "REFUSED: invalid destination URL"
+    return None

--- a/src/hunch/gate.py
+++ b/src/hunch/gate.py
@@ -113,15 +113,21 @@ class Gate:
 
     def mark_screen_approval(self):
         self._screen_ok_until = time.monotonic() + APPROVAL_WINDOW_S
+        self._screen_ok_target = getattr(self, "_screen_target", None)
         suppress_focus_notice(APPROVAL_WINDOW_S)
 
+    def bind_screen_target(self, target):
+        self._screen_target = target
+
     def screen_approved(self):
-        return time.monotonic() < self._screen_ok_until
+        return (time.monotonic() < self._screen_ok_until
+                and getattr(self, "_screen_ok_target", None) == getattr(self, "_screen_target", None))
 
     def front_gate(self, name, reason=""):
         """None if bringing `name` to the front may proceed, else a refusal message for the agent.
         Asks the user first (gates.app_to_front) unless they already approved a screen dialog
         moments ago, the gate is off, or the app is already frontmost (no real switch)."""
+        self.bind_screen_target(("app", name))
         if self.screen_approved() or not self.enabled("app_to_front"):
             return None
         if _frontmost()[0] == name:
@@ -139,10 +145,15 @@ def check_focus_steal(computer, actions, gate, confirm=False, reason=""):
     """Gate the focus-stealing actions in an `act` batch (key / click_xy / ref-less type — they
     use the shared keyboard/mouse and need the app frontmost). Returns None if the batch may
     run, else the refusal message. Sets the focus reason so the focus warning explains itself."""
+    from .targets import process_key
+    session = getattr(computer, "session", None)
+    gate.bind_screen_target((computer.app, process_key(getattr(session, "_identity", {})),
+                             getattr(session, "_selected_window", None)))
     stealing = [a for a in actions if computer._is_shared_input(a)]
     if stealing:
         set_focus_reason(reason)   # the focus-switch warning tells the user WHY
-    if stealing and not computer.simultaneous and not confirm and gate.enabled("focus_steal"):
+    if (stealing and not computer.simultaneous and not confirm
+            and not gate.screen_approved() and gate.enabled("focus_steal")):
         kinds = ", ".join(sorted({a.get("action") for a in stealing}))
         why = f" — {reason}" if reason else ""
         if not gate.confirm_dialog(f"{gate.app_name} wants to take over your screen ({kinds} on "
@@ -202,23 +213,15 @@ def applescript_hint(out, script=""):
 
 
 def applescript_empty_hint(script):
-    """Why a script that SUCCEEDED returned nothing — or "" if there's no known reason.
-
-    An empty result is the worst kind of answer: the script ran, nothing failed, and the agent
-    can't tell 'no windows' from 'this question can't be answered this way'. The common case is
-    asking System Events for a Chromium/Electron app's windows: those apps vend their UI to the
-    AX API, not to System Events' scripting bridge, so `count of windows` is a truthful-looking 0
-    no matter how many windows are on screen. Retrying the same script (the natural next move,
-    and the one that wastes turns) can never return anything else."""
+    """Explain the limits of an empty UI-scripting observation."""
     s = (script or "").lower()
     if "system events" not in s:
         return ""
     if "window" in s and "process" in s:
-        return ("\n[!] This returned EMPTY, and re-running it will too. System Events only sees "
-                "windows of apps that expose them to its scripting bridge — a Chromium/Electron "
-                "app (Cursor, VS Code, Slack, Discord, Chrome) reports 0 windows here even with "
-                "many open. Read its windows through the AX layer instead: snapshot(app=...) for "
-                "the focused window, or web_tabs after web_open for the CDP-driven copy.")
+        return ("\n[!] System Events UI scripting uses accessibility. An empty window enumeration "
+                "does not prove the app exposes no AX tree. Verify the process and permissions; "
+                "snapshot(app=...) also checks focused/main window and AXChildren fallbacks. "
+                "An attached CDP session is a separate surface with its own target identity.")
     return ""
 
 

--- a/src/hunch/local_mac.py
+++ b/src/hunch/local_mac.py
@@ -31,18 +31,13 @@ from Quartz import CGPoint, CGSize
 import Quartz
 
 
-# Frameworks that mark an app as "embedded Chromium" — its UI is web content that the OS does NOT
-# put in the background accessibility tree. General, not app-specific: covers Electron (Cursor,
-# VS Code, Discord, Slack, …) and CEF (Chromium Embedded Framework — Spotify and others).
-_EMBEDDED_CHROMIUM = ("Electron Framework.framework", "Chromium Embedded Framework.framework")
+# Framework detection identifies candidate recovery mechanisms, not AX/CDP availability.
+_EMBEDDED_CHROMIUM = ("Electron Framework.framework", "Chromium Embedded Framework.framework",
+                     "Codex Framework.framework")
 
 
 def _embedded_chromium(pid):
-    """Return the embedded-Chromium framework the app bundles (Electron or CEF), else None. Such an
-    app renders its UI as web content that is NOT exposed to the AX tree in the background (only
-    while frontmost, and only if accessibility is force-enabled) — so a background snapshot reads
-    empty. Real Electron also opens a CDP debug port (web_open); hardened embeddings (e.g. CEF) may
-    open NEITHER a debug port NOR an AX tree, leaving only pixels/manual."""
+    """Return a bundled Chromium framework, without classifying operation coverage."""
     try:
         app = NSRunningApplication.runningApplicationWithProcessIdentifier_(pid)
         url = app.bundleURL() if app else None
@@ -79,16 +74,9 @@ def _is_editor_terminal(el, pid):
     return bool(re.search(r"\bterminal\b", label))
 
 
-# ── forcing an embedded-Chromium app's tree to persist in the BACKGROUND ──────────────────
-# Verified 2026-07-18 on Discord (hardened Electron — strips --remote-debugging-port so CDP can't
-# attach): Chromium builds its web-content AX tree only while the app is active and TEARS IT DOWN on
-# deactivation (AXWindows → 0 the instant it loses focus). The Chromium switch --force-renderer-
-# accessibility flips it into permanent "complete" accessibility mode, so the FULL tree stays live
-# in the background (Discord: 558 nodes — servers, DMs, unread counts, usernames — read while Finder
-# was frontmost). The flag survives Discord's launcher even though the debug-port flag does not.
-# So embedded-Chromium apps ARE focus-free-readable as a TREE after a one-time force relaunch.
+# Explicit recovery option for embedded Chromium. Its effect must be measured for
+# the selected app/version/operation; a flag is not proof of background coverage.
 _FORCE_AX_FLAG = "--force-renderer-accessibility"
-_forced_ax = set()   # bundle ids / names we've already relaunched this session (avoid re-quitting)
 
 
 def _proc_has_force_ax(pid):
@@ -162,16 +150,34 @@ def _norm_app_name(s):
     return s.strip().casefold()
 
 
+def _running_identity(pid):
+    """Fresh stable identity for a running app; display names are not unique."""
+    app = NSRunningApplication.runningApplicationWithProcessIdentifier_(pid)
+    if app is None:
+        return {}
+    url = app.bundleURL()
+    from .targets import bundle_metadata
+    return {
+        "pid": pid,
+        "started_at": str(app.launchDate() or ""),
+        "activation_policy": int(app.activationPolicy()),
+        "bundle_id": str(app.bundleIdentifier() or ""),
+        "path": str(url.path() if url else ""),
+        "name": str(app.localizedName() or ""),
+        **(bundle_metadata(str(url.path())) if url else {}),
+    }
+
+
 def _resolve_app(app_name):
-    """Find the running app matching a user-typed name, tolerant of invisible marks / case. Returns
-    {name, pid} or None. Exact (normalized) match wins; else a unique prefix/substring match."""
-    apps = ax.list_apps()
-    want = _norm_app_name(app_name)
-    exact = [a for a in apps if _norm_app_name(a["name"]) == want]
-    if exact:
-        return exact[0]
-    part = [a for a in apps if want and want in _norm_app_name(a["name"])]
-    return part[0] if len(part) == 1 else None
+    """Resolve a single process, preserving identity and refusing ambiguity."""
+    from .targets import select_running
+    if str(app_name).startswith("pid:"):
+        try:
+            return _running_identity(int(str(app_name)[4:])) or None
+        except ValueError:
+            return None
+    apps = [{**a, **_running_identity(a["pid"])} for a in ax.list_apps()]
+    return select_running(app_name, apps)
 
 
 def _pids_named(name):
@@ -186,50 +192,23 @@ def _pids_named(name):
         return []
 
 
+def _process_alive(pid):
+    """Fresh kernel liveness; NSRunningApplication termination state can be cached."""
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
 def _enable_manual_ax(ax_app):
-    """Ask a Chromium/Electron app to build its accessibility tree without VoiceOver. Chromium
-    honors AXManualAccessibility=true from a trusted AT; harmless on non-Chromium apps. On its own
-    this is not enough for BACKGROUND reads (the tree still tears down on deactivate) — the launch
-    flag is what makes it persist — but it's a cheap belt-and-suspenders and helps while frontmost."""
+    """Request manual accessibility. Coverage and persistence need separate observation."""
     try:
         AXUIElementSetAttributeValue(ax_app, "AXManualAccessibility", True)
     except Exception:
         pass
-
-
-def _window_node_count(ax_app, cap=60):
-    """Rough descendant count of the app's current window — used to tell a still-loading Chromium
-    tree (a bare window shell, a handful of nodes) from a built one. Cheap: stops early at `cap`."""
-    win = ax.get_window(ax_app)
-    if win is None:
-        return 0
-    seen = [0]
-    def walk(el):
-        if seen[0] >= cap:
-            return
-        seen[0] += 1
-        for k in (ax.get_attr(el, ax.kAXChildrenAttribute) or []):
-            if seen[0] >= cap:
-                return
-            walk(k)
-    walk(win)
-    return seen[0]
-
-
-def _wait_tree_ready(pid, timeout=18.0):
-    """After a --force-renderer-accessibility (re)launch, Chromium needs a few seconds to render and
-    build its web-content AX tree — read too early and you get just the window shell. Poll until the
-    window has real content (or timeout). Returns the built AXUIElement app ref."""
-    deadline = time.time() + timeout
-    ax_app = AXUIElementCreateApplication(pid)
-    _enable_manual_ax(ax_app)
-    while time.time() < deadline:
-        if _window_node_count(ax_app) >= 15:
-            return ax_app
-        time.sleep(0.6)
-        ax_app = AXUIElementCreateApplication(pid)
-        _enable_manual_ax(ax_app)
-    return ax_app
 
 
 # Deterministically alert the user whenever Hunch is about to bring an app to the front (a real
@@ -403,26 +382,24 @@ class MacSession:
         dismisses its open context menus/popups (which breaks right_click -> menu)."""
         if not self._pid:
             return False
+        if not self._validate_target():
+            return False
+        guard = getattr(self, "_shared_guard", None)
+        if guard and guard():
+            return False
         if _frontmost()[1] == self._pid:
             return True  # already active — no focus switch happens
         _announce_front(getattr(self, "_app_name", None) or "an app")  # deterministic focus warning
-        # `open -a` (LaunchServices) reliably fronts the app. NSRunningApplication.
-        # activateWithOptions_ is restricted on macOS 14+ (cooperative activation) and
-        # silently fails for a background process like this MCP — the cause of
-        # "target app not frontmost" refusals.
-        # macOS focus-stealing prevention suppresses an activation that comes right after
-        # another focus change (e.g. our own confirm dialog). A single `open -a` gives up
-        # too fast, so RE-ISSUE it over a few seconds to punch through the suppression window,
-        # polling for the app to actually reach the front.
-        name = getattr(self, "_app_name", None)
+        # Cooperative activation may be refused; address the exact process and
+        # verify the foreground PID before posting any shared input.
         deadline = time.time() + 4.0
         while time.time() < deadline:
-            if name:
-                subprocess.run(["open", "-a", name], check=False)
+            app = NSRunningApplication.runningApplicationWithProcessIdentifier_(self._pid)
+            if app:
+                if not app.activateWithOptions_(2):
+                    _activate_process(self._pid)
             else:
-                app = NSRunningApplication.runningApplicationWithProcessIdentifier_(self._pid)
-                if app:
-                    app.activateWithOptions_(2)
+                _activate_process(self._pid)
             settle = time.time() + 1.0
             while time.time() < settle:
                 if _frontmost()[1] == self._pid:
@@ -539,57 +516,47 @@ class MacSession:
     def _resolve_window(self, app_name):
         """Resolve app -> (window element, real app name, error). On failure the
         error is the (text, info) tuple snapshot()/find() should return as-is.
-        Side effects: sets self._pid/_app_name, handles the embedded-Chromium
-        force-accessibility relaunch dance."""
+        Observation never launches, quits, or activates an application."""
+        from .targets import TargetError, process_key
+        match = None
         if app_name is None:
             app_name, pid = _frontmost()
         else:
-            match = _resolve_app(app_name)
+            try:
+                match = _resolve_app(app_name)
+            except TargetError as error:
+                self._invalidate_refs()
+                return None, app_name, (str(error), {"refs": 0, "app": app_name})
             pid = match["pid"] if match else None
             if match:
                 app_name = match["name"]   # use the app's REAL name (with any invisible marks) downstream
         if pid is None:
+            self._invalidate_refs()
             return None, app_name, (f"(app {app_name!r} not found)",
                                     {"est_tokens": 20, "refs": 0, "app": app_name})
         self._pid = pid
         self._app_name = app_name  # used by activate() for reliable `open -a` fronting
-        # Reading is FOCUS-FREE: native (AppKit) apps expose their AX tree while backgrounded, so we
-        # never bring an app forward just to look. Embedded-Chromium apps (Electron/CEF) are the
-        # exception — Chromium tears down its web-content AX tree on deactivation, so a background read
-        # sees no window. The fix is NOT to steal focus or fall back to pixels: relaunch the app ONCE
-        # with --force-renderer-accessibility (focus-free, open -g), which keeps the full tree live in
-        # the background permanently. After that, this same app reads as a rich tree with no focus cost.
-        front = NSWorkspace.sharedWorkspace().frontmostApplication()
-        already_front = bool(front and front.processIdentifier() == pid)
+        identity = match or {"pid": pid, "name": app_name, **_running_identity(pid)}
+        if process_key(identity) != process_key(getattr(self, "_identity", {})):
+            self._invalidate_refs()
+        self._identity = identity
         ax_app = AXUIElementCreateApplication(pid)
-        if _embedded_chromium(pid):
+        if (AXIsProcessTrusted() and _embedded_chromium(pid)
+                and getattr(self, "_manual_ax_identity", None) != process_key(identity)):
             _enable_manual_ax(ax_app)
-            # In the background a Chromium app vends a bare window SHELL (a few nodes) until the flag
-            # forces the tree to persist — so "unbuilt" means a tiny node count, not a missing window.
-            built = _window_node_count(ax_app) >= 15
-            need_force = (not already_front) and (not built) and not _proc_has_force_ax(pid)
-            if need_force and app_name not in _forced_ax:
-                # One-time focus-free relaunch so the tree persists in the background. Discord et al.
-                # restore their exact prior view on relaunch, so this is a brief blink, not data loss.
-                _forced_ax.add(app_name)
-                launch_app(app_name, force_accessibility=True, background=True)
-                # re-resolve the new pid FRESH (pgrep) — ax.list_apps() is cached and would hand back
-                # the old, now-dead pid, so the read would target a corpse and come back empty.
-                flagged = [p for p in _pids_named(app_name) if _proc_has_force_ax(p)]
-                if flagged:
-                    pid = self._pid = flagged[0]
-                    ax_app = _wait_tree_ready(pid)
+            self._manual_ax_identity = process_key(identity)
         win = ax.get_window(ax_app)
+        selected = getattr(self, "_selected_window", None)
+        if selected:
+            observations, _ = ax.discover_windows(ax_app)
+            if selected[0] != process_key(identity) or not any(w[0] == selected[1] for w in observations):
+                self._invalidate_refs()
+                return None, app_name, ("selected window is stale; inspect targets again", {"refs": 0})
+            win = selected[1]
+        if win != getattr(self, "_window", None):
+            self._invalidate_refs()
+        self._window = win
         if win is None:
-            if _embedded_chromium(pid) and not already_front:
-                return None, app_name, (
-                    (f"“{app_name}” is an embedded-Chromium app whose accessibility tree isn't up "
-                     f"yet. Call launch_app(\"{app_name}\", force_accessibility=true) once — it "
-                     f"relaunches it FOCUS-FREE with the flag that keeps its full tree readable in "
-                     f"the background — then snapshot again. If the tree is STILL empty after that, "
-                     f"the app blocks AX entirely: use its AppleScript dictionary, or tell the user "
-                     f"it needs Screen Recording + pixel control."),
-                    {"est_tokens": 70, "refs": 0, "app": app_name, "embedded_chromium": True})
             if not AXIsProcessTrusted():
                 return None, app_name, (
                     (f"(no window for {app_name} — and this process is NOT trusted for "
@@ -599,10 +566,31 @@ class MacSession:
                      "restart the host. `hunch doctor` explains.)"),
                     {"est_tokens": 60, "refs": 0, "app": app_name})
             return None, app_name, (
-                (f"(no window for {app_name} — the app may have no open window; open one "
-                 "via launch_app or open_file, or check with the user, then retry)"),
+                (f"(no AX window found for {app_name}, PID {pid}, in the current state. "
+                 "This does not establish that the app has no accessibility support. "
+                 "Check the selected process and open windows; an existing CDP endpoint or "
+                 "an authorized accessibility/debugging relaunch may provide another surface.)"),
                 {"est_tokens": 40, "refs": 0, "app": app_name})
         return win, app_name, None
+
+    def _invalidate_refs(self):
+        self.registry.clear()
+        self._keymap.clear()
+        self._ref_keys.clear()
+
+    def _validate_target(self):
+        from .targets import process_key
+        identity = getattr(self, "_identity", None)
+        if identity and process_key(_running_identity(identity["pid"])) != process_key(identity):
+            self._invalidate_refs()
+            return False
+        window = getattr(self, "_window", None)
+        if identity and window is not None:
+            windows, _ = ax.discover_windows(AXUIElementCreateApplication(identity["pid"]))
+            if not any(item[0] == window for item in windows):
+                self._invalidate_refs()
+                return False
+        return True
 
     def _snapshot_scoped(self, ref, max_depth, max_nodes, compact, max_children=None):
         """Re-walk ONLY the subtree under a known ref, at generous depth. Does NOT
@@ -610,6 +598,7 @@ class MacSession:
         place (the persistent _keymap makes them identical to full-walk refs).
         The sibling cap defaults HIGHER here (_SCOPED_MAX_CHILDREN) so scoping into
         a big list's container pages in far more rows than the full-window walk."""
+        self._validate_target()
         el = self.registry.get(ref)
         key = self._ref_keys.get(ref)
         app = getattr(self, "_app_name", None) or "app"
@@ -768,6 +757,7 @@ class MacSession:
 
     # ── actions ─────────────────────────────────────────────────────────
     def _el(self, ref):
+        self._validate_target()
         el = self.registry.get(ref)
         if el is None:
             raise StaleRef(ref)
@@ -913,6 +903,16 @@ class MacSession:
         moves the shared cursor and lands on whichever window is frontmost."""
         el = self._el(ref)
         role = str(ax.get_attr(el, ax.kAXRoleAttribute) or "")
+        # A click on an editable text control means "put the insertion point here".
+        # Some native sheets advertise AXConfirm on the field itself (notably the
+        # Go to Folder sheet). Treating that as a button action leaves keyboard
+        # input aimed at the previous control while claiming the click worked.
+        # AXFocused is focus-free and, unlike AXConfirm, can be verified.
+        if role in ("AXTextField", "AXTextArea", "AXComboBox", "AXSearchField"):
+            if AXUIElementSetAttributeValue(el, kAXFocusedAttribute, True) == 0:
+                time.sleep(0.1)
+                if ax.get_attr(el, kAXFocusedAttribute):
+                    return f"focused {ref}"
         # Sidebar/list rows are the main SwiftUI false-success surface: AXPress
         # returns 0 while the pane does not change. Capture the window title so
         # we can refuse to call that a navigation.
@@ -1019,7 +1019,9 @@ class MacSession:
                     f"CDP instead: web_open(app=\"{app}\") then web_act a 'type' action on the "
                     f"terminal — that injects real keystrokes into the PTY.")
         if AXUIElementSetAttributeValue(el, kAXValueAttribute, text) == 0:
-            return f"set text on {ref}"
+            if str(ax.get_attr(el, kAXValueAttribute)) == str(text):
+                return f"set text on {ref} (readback verified)"
+            return f"{ref}: AX accepted the write but readback did not match; result unverified"
         if not allow_keystrokes:
             return f"{ref}: field not AX-settable; typing would use the shared keyboard — skipped"
         if not self.activate():
@@ -1163,6 +1165,7 @@ def _type_text(text):
 
 
 _KEYCODES = {"return": 36, "enter": 36, "tab": 48, "space": 49, "delete": 51,
+             "backspace": 51,
              "escape": 53, "left": 123, "right": 124, "down": 125, "up": 126,
              # US-QWERTY letters/digits, so ⌘-shortcuts (⌘Q, ⌘C, ⌘W, ...) work
              "a": 0, "s": 1, "d": 2, "f": 3, "h": 4, "g": 5, "z": 6, "x": 7, "c": 8,
@@ -1237,142 +1240,110 @@ def list_running_apps():
     return ", ".join(sorted(a["name"] for a in ax.list_apps()))
 
 
-def launch_app(name, force_accessibility=False, background=False):
-    """Launch or focus an app. background=True launches it WITHOUT bringing it to
-    the front (open -g) — so it doesn't steal the user's view (for simultaneous use).
-    force_accessibility relaunches an Electron/Chromium app with the Chromium flag
-    that makes its accessibility tree visible to snapshot (otherwise it reads empty)."""
-    bg = ["-g"] if background else []  # -g: open in the background, don't foreground
+def launch_app(name, force_accessibility=False, background=False, debugging_port=None):
+    """Launch explicitly; a forced-accessibility restart must quit gracefully."""
+    bg = ["-g"] if background else []
+    match = _resolve_app(name)
+    identity = _running_identity(match["pid"]) if match else {}
+    target = identity.get("path") or name
+    profile_args = []
+    if (force_accessibility or debugging_port) and match and "--user-data-dir" in _proc_cmdline(match["pid"]):
+        from .cdp import _OWNED_ENDPOINTS
+        from .targets import process_key
+        owned = next((record for record in _OWNED_ENDPOINTS.values()
+                      if process_key(record["identity"]) == process_key(identity)), None)
+        if owned is None:
+            return "REFUSED: current custom profile is not owned/verified; attach to its endpoint without restarting"
+        profile_args = [f"--user-data-dir={owned['profile']}"]
+    if (force_accessibility or debugging_port) and match:
+        app = NSRunningApplication.runningApplicationWithProcessIdentifier_(match["pid"])
+        if app is None:
+            return f"REFUSED: selected process for {name} disappeared; resolve it again"
+        app.terminate()
+        deadline = time.monotonic() + 6
+        while _process_alive(match["pid"]) and time.monotonic() < deadline:
+            time.sleep(0.2)
+        if _process_alive(match["pid"]):
+            return f"REFUSED: {name} did not quit gracefully; resolve its save/confirmation prompt"
     if not background:
-        _announce_front(name)  # foreground launch fronts the app — warn deterministically
+        _announce_front(name)
+    args = ["open", *bg, "-a", target]
     if force_accessibility:
-        # Relaunch with the Chromium flag that keeps an embedded-Chromium app's accessibility tree
-        # live in the BACKGROUND (see _proc_has_force_ax / snapshot). All process checks here use
-        # _pids_named (fresh pgrep), NOT ax.list_apps() — that list is cached in a no-runloop process,
-        # so a killed app still shows as running and the relaunch never happens.
-        old_pids = set(_pids_named(name))
-        # CRITICAL: `open -a X --args` reuses a running instance and IGNORES the new args, so the flag
-        # would never take. The app must be FULLY GONE before we reopen. Quit gracefully first (clean,
-        # lets the app save state), then hard-kill if it won't go: some apps (Discord) IGNORE SIGTERM,
-        # so the reliable fallback is SIGKILL (pkill -9), which needs no Automation permission.
-        if old_pids:
-            subprocess.run(["osascript", "-e", f'tell application {as_str(name)} to quit'], check=False)
-            gone_by = time.time() + 4
-            while time.time() < gone_by and _pids_named(name):
-                time.sleep(0.3)
-            if _pids_named(name):
-                subprocess.run(["pkill", "-9", "-x", name], check=False)   # SIGTERM-ignoring apps
-                hard_by = time.time() + 5
-                while time.time() < hard_by and _pids_named(name):
-                    time.sleep(0.3)
-            time.sleep(1)
-        subprocess.run(["open", *bg, "-a", name, "--args", _FORCE_AX_FLAG], check=False)
-        # Wait for the NEW instance — a pid we didn't see before that actually carries the flag —
-        # before timing the tree build; polling the old/dying pid was why an early read came back empty.
-        new_pid, deadline = None, time.time() + 20
-        while time.time() < deadline and new_pid is None:
-            for p in _pids_named(name):
-                if p not in old_pids and _proc_has_force_ax(p):
-                    new_pid = p
-                    break
-            if new_pid is None:
-                time.sleep(0.4)
-        if new_pid:
-            _wait_tree_ready(new_pid)   # block until the a11y tree is built, not just the window shell
-        else:
-            time.sleep(6)
-    else:
-        subprocess.run(["open", *bg, "-a", name], check=False)
-        time.sleep(4)
-    return (f"launched {name}" + (" in background" if background else "")
-            + (" (accessibility forced)" if force_accessibility else ""))
+        args += ["--args", _FORCE_AX_FLAG, *profile_args]
+    elif debugging_port:
+        args += ["--args", f"--remote-debugging-port={int(debugging_port)}",
+                 "--remote-debugging-address=127.0.0.1", *profile_args]
+    result = subprocess.run(args, check=False, capture_output=True, text=True)
+    if result.returncode:
+        return f"failed to launch {name}: {result.stderr.strip() or result.returncode}"
+    if debugging_port:
+        from .cdp import _wait_for_port, verify_endpoint
+        _wait_for_port(debugging_port, timeout=15)
+        verify_endpoint(debugging_port, target)
+        return f"debugging endpoint verified for {target} on :{debugging_port}"
+    if force_accessibility:
+        deadline = time.monotonic() + 12
+        while time.monotonic() < deadline:
+            current = _resolve_app(target)
+            if current and _proc_has_force_ax(current["pid"]):
+                return f"launched {name} with accessibility flag; operation coverage remains unverified"
+            time.sleep(0.3)
+        return f"REFUSED: launch requested for {name}, but the accessibility flag was not verified"
+    return f"launch requested for {name}" + (" in background" if background else "")
+
+
+def _activate_process(pid):
+    """Exact-process fallback when cooperative AppKit activation is refused.
+
+    Callers must pass the shared-input gate first and verify foreground afterward.
+    """
+    try:
+        result = subprocess.run([
+            "osascript", "-e", 'tell application "System Events" to set frontmost of '
+            f'first application process whose unix id is {int(pid)} to true'],
+            capture_output=True, text=True, timeout=3)
+        return result.returncode == 0
+    except subprocess.TimeoutExpired:
+        return False
 
 
 def focus_app(name):
-    """Bring an app to the front (LaunchServices — more reliable than activating
-    from a background process)."""
-    _announce_front(name)  # this is an explicit focus switch — warn deterministically
-    subprocess.run(["open", "-a", name], check=False)
-    time.sleep(1.0)
-    return f"focused {name}"
+    """Activate the resolved process and verify the foreground PID."""
+    target = _resolve_app(name)
+    if target is None:
+        return f"REFUSED: {name} is not running; launch it explicitly first"
+    _announce_front(name)
+    app = NSRunningApplication.runningApplicationWithProcessIdentifier_(target["pid"])
+    if (app is None or not app.activateWithOptions_(2)) and not _activate_process(target["pid"]):
+        return f"REFUSED: activation request failed for {name}"
+    for _ in range(20):
+        if _frontmost()[1] == target["pid"]:
+            return f"focused {name} (pid {target['pid']})"
+        time.sleep(0.1)
+    return f"UNVERIFIED: activation requested for {name}, but foreground PID did not match"
 
 
 def quit_app(name):
     """Quit an app cleanly via the OS — reliable regardless of focus or tray
-    behavior, unlike ⌘Q. Polls until it's actually gone (a graceful quit can lag),
-    escalating to a force-quit if it lingers."""
-    r = next((a for a in ax.list_apps() if a["name"] == name), None)
+    behavior, unlike ⌘Q. Polls until it's actually gone; never force-quits."""
+    r = _resolve_app(name)
     if r is None:
         return f"{name} is not running"
     app = NSRunningApplication.runningApplicationWithProcessIdentifier_(r["pid"])
     app.terminate()
     # Poll the app object's own termination flag — the NSWorkspace running-apps
     # list lags behind an actual quit, so checking it gives false "still running".
-    for i in range(20):  # up to ~6s; escalate to force-quit partway
+    for i in range(20):  # up to ~6s; never force-quit implicitly
         time.sleep(0.3)
-        if app.isTerminated():
+        if not _process_alive(r["pid"]):
             return f"quit {name}"
-        if i == 8:
-            app.forceTerminate()
     return f"{name} still running (it may be showing a save/confirm prompt)"
 
 
 # ── LocalComputer: the tool-use adapter (same interface as Docker computer.py) ──
-TOOLS = [
-    {"name": "snapshot",
-     "description": ("Look at the screen. Returns the focused app's UI as an accessibility "
-                     "tree — one element per line tagged with a [ref] like [e12]. You act on "
-                     "elements by ref."),
-     "input_schema": {"type": "object", "properties": {}}},
-    {"name": "act",
-     "description": ("Execute one or more UI actions in order by element ref, then get the updated "
-                     "screen. Primitives: click (activate/press an element), right_click (open an "
-                     "element's context menu — e.g. to reach 'Leave Server'), select (select a list "
-                     "row/cell/item), type (type text; with a ref it sets that field's value), "
-                     "menu (invoke a menu-bar command by path, e.g. path=['File','Move to Trash'] — "
-                     "FOCUS-FREE, the preferred stand-in for keyboard shortcuts like ⌘⌫/⌘S/⌘W), "
-                     "key (press a key with optional modifiers — STEALS FOCUS, only when no menu/field "
-                     "equivalent exists), window (move/resize an app's MAIN window FOCUS-FREE via "
-                     "x/y/w/h — the right way to tile/position windows; targets the main window, not a "
-                     "sheet/dialog. Pass `app` to target a specific app's window; to tile TWO different "
-                     "apps side by side give each window action its own `app`, e.g. "
-                     "{action:window,app:'TextEdit',x:0,w:756,...} then {action:window,app:'Notes',x:756,w:756,...}), "
-                     "click_xy (pixel click — last-resort fallback, STEALS FOCUS). "
-                     "Prefer the focus-free primitives (click/select/right_click/type-into-ref/menu/window)."),
-     "input_schema": {"type": "object", "properties": {"actions": {"type": "array", "items": {
-         "type": "object", "properties": {
-             "action": {"type": "string",
-                        "enum": ["click", "right_click", "select", "type", "menu", "key",
-                                 "window", "drag", "click_xy"]},
-             "ref": {"type": "string"}, "text": {"type": "string"},
-             "path": {"type": "array", "items": {"type": "string"}},
-             "key": {"type": "string"}, "modifiers": {"type": "array", "items": {"type": "string"}},
-             "x": {"type": "integer"}, "y": {"type": "integer"},
-             "w": {"type": "integer"}, "h": {"type": "integer"},
-             "app": {"type": "string"},
-             "from_ref": {"type": "string"}, "to_ref": {"type": "string"},
-             "from_x": {"type": "integer"}, "from_y": {"type": "integer"},
-             "to_x": {"type": "integer"}, "to_y": {"type": "integer"}},
-         "required": ["action"]}}}, "required": ["actions"]}},
-    {"name": "screenshot", "description": "See the screen as an image.",
-     "input_schema": {"type": "object", "properties": {}}},
-    # ── App lifecycle (OS-backed, reliable) — manage apps, don't UI-drive them ──
-    {"name": "list_apps", "description": "List the running GUI apps you can target.",
-     "input_schema": {"type": "object", "properties": {}}},
-    {"name": "launch_app",
-     "description": ("Launch or focus an app (reliable OS call — use this instead of clicking Dock "
-                     "icons). Set force_accessibility=true for an embedded-Chromium app (Electron/CEF) "
-                     "whose tree reads empty — it relaunches the app so its accessibility tree may "
-                     "become visible to snapshot (some hardened apps still won't expose it)."),
-     "input_schema": {"type": "object", "properties": {
-         "name": {"type": "string"}, "force_accessibility": {"type": "boolean"}}, "required": ["name"]}},
-    {"name": "quit_app",
-     "description": ("Quit an app via the OS — reliable regardless of focus (use this instead of ⌘Q, "
-                     "which is unreliable on background apps)."),
-     "input_schema": {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}},
-    {"name": "focus_app", "description": "Bring an app to the front (reliable OS call).",
-     "input_schema": {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}},
-]
+from .tool_registry import BASE_TOOLS
+TOOLS = [tool for tool in BASE_TOOLS if tool["name"] in {
+    "snapshot", "act", "screenshot", "list_apps", "launch_app", "quit_app", "focus_app"}]
 
 
 _REF_LINE = re.compile(r"\[(e\d+)\]")
@@ -1496,7 +1467,9 @@ class LocalComputer:
                           '[{"action":"click","ref":"e12"}] — each item must be an object')
         return actions, None
 
-    def act(self, actions):
+    def act(self, actions, detailed=False, postcondition=None):
+        from .results import action_receipt, validate_postcondition
+        validate_postcondition(postcondition)
         actions, bad = self._coerce_actions(actions)
         if bad:
             return bad
@@ -1555,6 +1528,8 @@ class LocalComputer:
                     lines.append(f"clicked ({a['x']},{a['y']})")
                 else:
                     lines.append(f"unknown action {act}")
+                if lines and any(marker in lines[-1].lower() for marker in ("refused", "skipped", "unverified", "not selectable")):
+                    break
                 time.sleep(0.6)
             except StaleRef:
                 lines.append(f"ref {a.get('ref')} is stale — re-snapshot")
@@ -1565,6 +1540,18 @@ class LocalComputer:
         time.sleep(0.8)
         d = self.session.disturbances
         delta = {k: d[k] - _dist_before[k] for k in d if d[k] > _dist_before[k]}
+        outcome = None
+        if detailed or postcondition is not None:
+            def read(ref, field):
+                attributes = {"value": "AXValue", "title": "AXTitle", "enabled": "AXEnabled",
+                              "selected": "AXSelected", "expanded": "AXExpanded"}
+                element = self.session._el(ref)
+                error, value = ax.read_attr(element, attributes[field])
+                if error:
+                    raise ValueError(f"AX readback failed ({error})")
+                return value
+            outcome = action_receipt(lines, len(actions), "ax", getattr(self.session, "_identity", None),
+                                     delta, postcondition, read)
         receipt = ""
         if delta:
             used = ", ".join(f"{v} {k.replace('_', ' ')}" for k, v in delta.items())
@@ -1577,6 +1564,8 @@ class LocalComputer:
         screen = ("Screen changes since your last view (~ changed, + new; unchanged lines "
                   "omitted — call snapshot for the full tree):\n" + diff
                   ) if diff is not None else "Screen now:\n" + shot
+        if outcome is not None:
+            return {**outcome, "observation": screen}
         return "Executed:\n" + "\n".join(lines) + receipt + "\n\n" + screen
 
     def handle(self, tool_use):
@@ -1590,7 +1579,8 @@ class LocalComputer:
             if name == "snapshot":
                 content = self.snapshot()
             elif name == "act":
-                content = self.act(args["actions"])
+                content = self.act(args["actions"], detailed=args.get("detailed", False),
+                                   postcondition=args.get("postcondition"))
             elif name == "list_apps":
                 content = list_running_apps()
             elif name == "launch_app":

--- a/src/hunch/os_ops.py
+++ b/src/hunch/os_ops.py
@@ -72,16 +72,12 @@ def reveal(paths):
 
 def open_path(path, app=None):
     """Open a file/folder/URL with its default app (or a named app) — focus-free launch."""
-    ws = NSWorkspace.sharedWorkspace()
     target = _abspath(path) if os.path.exists(_abspath(path)) else str(path)
-    if app:
-        subprocess.run(["open", "-a", app, target], check=False)
-        return f"opened {target} with {app}"
-    if os.path.exists(target):
-        ok = ws.openURL_(NSURL.fileURLWithPath_(target))
-    else:
-        ok = ws.openURL_(NSURL.URLWithString_(target))  # web URL / scheme
-    return f"opened {target}" if ok else f"FAILED to open {target}"
+    command = ["open", "-g"] + (["-a", app] if app else []) + [target]
+    result = subprocess.run(command, check=False, capture_output=True, text=True)
+    if result.returncode:
+        return f"FAILED to open {target}: {result.stderr.strip() or result.returncode}"
+    return f"background open requested for {target}" + (f" with {app}" if app else "")
 
 
 # ── Clipboard (focus-free; replaces ⌘C / ⌘V keystrokes) ──

--- a/src/hunch/playbook.py
+++ b/src/hunch/playbook.py
@@ -1,169 +1,78 @@
-"""The Hunch playbook — the agent-facing instruction set shared by the MCP server
-(FastMCP instructions) and the agent loop (system prompt). Pure string module: no
-heavy imports; importable without pyobjc/mcp/anthropic.
+"""Model-facing runtime contract shared by MCP and provider backends."""
+
+HUNCH_PLAYBOOK = """Hunch controls a real, logged-in Mac. Prefer the most direct usable interface:
+OS APIs, declared application operations/Apple Events, CDP, native AX, then explicitly gated
+shared-screen input. Respect the user's chosen app/account and the host's background constraints.
+
+TARGETS AND CAPABILITIES
+- list_apps lists running apps. app_target inspects exact process identities and native windows;
+  select=true binds a process/window without bringing it forward. Names and bundle IDs may be
+  ambiguous: use the returned pid:N selector and window handle. Reinspect after a process restart.
+- snapshot/find read native AX. They never launch, quit, or restart an app. An empty/partial tree,
+  zero AXWindows, or a System Events zero-window result does not prove an app lacks AX support.
+- app_capabilities(app, operation) reports current evidence and bounded recovery plans. It may
+  offer manual accessibility enablement, existing CDP attachment, or a graceful accessibility/debug
+  restart. app_recover(plan_id, target_id) executes one fresh plan under host policy.
+- A recovery result verifies only what its evidence says. Endpoint attachment is not proof of
+  successful navigation. If renderer selection is ambiguous, pass an exact returned target_id.
+- Electron apps may expose useful AX, CDP, both, or neither for a particular operation. Check the
+  current process/window/launch state. Do not forget debugging enablement when CDP is unavailable.
+  Relaunches can interrupt work and need applicable authorization; do not repeat a failed restart.
+
+NATIVE OBSERVATION AND ACTION
+- snapshot yields eN refs. find searches a bounded tree; snapshot(ref=...) expands a known subtree.
+  Respect truncation markers. Refs expire across process/window changes; use fresh refs after changes.
+- act supports click/select/right_click/type with a ref, menu paths, and window geometry.
+  AX press/value writes can be accepted without taking effect. Verify value readback or changed
+  panel/content before reporting task completion. A successful dispatch alone is unverified.
+- Native key, click_xy, drag, and type without a ref use the shared keyboard/cursor. An AX fallback
+  may also need shared input. These require execution-time authorization and are refused in
+  background mode. A host-enforced background constraint cannot be weakened by simultaneous_mode.
+- Prefer open_file(path, app=...) to navigating Open/Save panels. Prefer menu paths to keyboard
+  shortcuts. For SwiftUI toggles, inspect the actual checkbox/switch and verify its value.
+  val='0' is off and val='1' is on; do not invent defaults write commands to change settings.
+- act returns a delta where possible; snapshot returns the full bounded view. Stop after a failed
+  prerequisite and inspect again instead of continuing an action batch with invalid assumptions.
+
+CDP
+- web_open starts/reuses a verified dedicated instance. Its profile may differ from the user's
+  current app. An unrelated listening port is not permission to attach to or restart that process.
+- web_snapshot reads the selected renderer's accessibility semantics; CDP resolves refs to DOM nodes
+  for action. web_screenshot captures that renderer, including while backgrounded. OS screenshot
+  captures the physical foreground screen and is a different surface.
+- web_tabs/web_switch_tab select renderer windows. Electron targets are pinned; unrelated popups
+  cannot steal the session. Native window refs and CDP refs are separate.
+- For editor terminals, use renderer input through CDP and verify output. An AX field write can
+  reach a screen-reader mirror without reaching the terminal. Bind the intended workspace first.
+- web_act type replaces fields and selects native select options by visible text. Renderer
+  click_xy/drag/key actions do not move the macOS cursor. Verify their effects.
+- Use observed/user-provided URLs. Private developer origins require host configuration through
+  allowed_web_origins. This checks navigation requests; it is not a network sandbox for redirects,
+  links, subresources, or arbitrary application traffic.
+- web_restart can gracefully restart only a verified owned process and preserves its profile.
+  Attached external processes need explicit app recovery.
+
+DIRECT OPERATIONS
+- If the requested operation has no usable background interface, report the specific gap.
+  Hunch Learn and installed learned operations are not included in this runtime release.
+- AppleScript may control applications, launch UI, or execute shell commands. Arbitrary scripts
+  have no automatic focus-free guarantee; strict host policy may refuse them. A timeout is
+  inconclusive. Report missing permissions only from explicit denial evidence/error codes.
+- Do not read ~/Library/Messages/chat.db or request Full Disk Access by default. Prefer Messages
+  scripting/AX. For an explicitly named webmail account, make at most one small native account probe;
+  if the account cannot be confirmed, use its signed-in website without repeatedly probing Mail.
+- trash is recoverable deletion; file_op handles copy/move/mkdir. Finder reveal changes the
+  foreground; clipboard_set changes the shared clipboard. Report these disturbances accurately.
+
+CREDENTIALS AND RESULTS
+- Use web_fill_login/web_fill_secret for stored credentials; never request secret values in chat.
+  Known filled strings are redacted from subsequent tool text. Screenshots are blocked afterward
+  because text filtering cannot prevent visual disclosure. Transformed echoes are not universally
+  protected. Respect credential destination binding; use interactive login for unbound credentials.
+- Report verified, performed-but-unverified, blocked, or failed outcomes honestly. Read receipts.
+  act/web_act detailed=true returns structured status. Optional postcondition={ref,field,equals}
+  verifies one final field (value/title/enabled/selected/expanded), not every intermediate action.
+  Distinguish current-state limitations from general app compatibility claims.
+- Respect denied actions and existing authorization. Obtain intent for consequential outward
+  actions (send, submit, purchase) when the user has not already authorized them.
 """
-
-HUNCH_PLAYBOOK = """Hunch drives this Mac across THREE focus-free layers plus a gated last resort.
-ALWAYS pick the most direct layer for the task — it's faster, more reliable, and (except the
-last) never disturbs the user's screen. Prefer a direct API over clicking a UI.
-
-NATIVE-FIRST: when the service behind a task has a native Mac app INSTALLED, do the task in that
-app — NOT its website. Controlling real apps is Hunch's edge over a browser bot: email → Mail.app
-(not gmail.com), calendar → Calendar.app, texts → Messages, notes/todos → Notes/Reminders, music →
-the Music/Spotify app (not open.spotify.com), files → Finder/OS-API (not drive.google.com for local
-files). Check `list_apps` (or launch_app's error) if unsure what's installed. Drop to the website
-only when: no native app is installed, the native app isn't signed into the needed account (e.g.
-Mail has no accounts configured), or the capability genuinely exists only on the web — and say
-which of those it was. For an explicitly named webmail account (for example, an @gmail.com address),
-make at most one small native account probe; if it times out or cannot confirm that account, use the
-signed-in website instead of grinding on Mail or asking for permissions. The browser is the fallback,
-not the default.
-STAY NATIVE even for embedded-Chromium apps (Electron/CEF: Discord, Slack, Spotify…). Even hardened
-ones that strip the CDP debug port ARE readable focus-free as a TREE: `snapshot(app)` auto-relaunches
-the app once with the accessibility flag (focus-free `open -g`; the app restores its prior view) so
-its full web UI appears in the background AX tree — verified on Discord (200+ refs: servers, DMs,
-unread counts, usernames — read while another app was frontmost). So `snapshot`/`act` are the path,
-same as any native app. Only if the tree STILL reads empty after that (a truly locked-down app) do
-you fall to VISION (`screenshot` + gated `click_xy`/`key`). Do NOT reroute to the service's website —
-that's the browser-bot path Hunch exists to beat; go to the web only if the user asks.
-
-LAYERS (most-direct first):
-1) OS-API — files, clipboard, apps. `trash(paths)` to DELETE files (never Finder + ⌘⌫);
-   `file_op(move/copy/mkdir)`; `open_file` for files/URLs/app deep-links; `clipboard_get/set`
-   instead of ⌘C/⌘V; `launch_app`/`quit_app`/`focus_app`/`list_apps` for app lifecycle.
-2) AppleScript — `applescript(script)` gives focus-free control of scriptable native apps:
-   Mail (send/read), Messages, Notes, Reminders, Calendar, Music/Spotify (playback), Finder,
-   Safari. Prefer this over clicking those apps' UI. Risky scripts auto-prompt the user.
-3) Web + Electron via CDP — `web_open`/`web_snapshot`/`web_act`/`web_login`/`web_restart`/
-   `web_screenshot` drive any browser or Electron app focus-free. READ a page with `web_snapshot`,
-   NOT the OS `screenshot` (that grabs the physical screen = the user's own window in the background);
-   `web_screenshot` is the focus-free way to see the CDP page as pixels. FORMS: `web_act` "type"
-   REPLACES a field and picks a native <select> option by its visible text (type "January") — NEVER
-   click a native dropdown. CANVAS EDITORS (Google Docs/Slides, drawing tools): if the editable
-   surface has no ref, `web_screenshot`, then `web_act` click_xy at the visual insertion point,
-   then `web_act` type WITHOUT a ref. Coordinate clicks/drags are injected into the background
-   renderer and do not move the user's cursor or focus the OS window.
-   NEW TABS: if a click/form opens a new tab, the next `web_snapshot` AUTO-FOLLOWS it — so just
-   snapshot again to reach the new page. `web_tabs` lists open tabs; `web_switch_tab(i)` moves
-   deliberately (back to a prior tab, or if auto-follow picked the wrong one).
-   LINKS: to follow a link ("Apply", "Sign in", etc.) CLICK it by ref — its href/redirect knows the
-   real destination. NEVER `navigate` to a URL you guessed or constructed (e.g. apply.<site>.com);
-   only navigate to URLs the user gave you or that you read from the page. A guessed URL usually
-   404s / doesn't resolve and sends you nowhere.
-4) Native UI via Accessibility — `snapshot`/`act` for NATIVE (AppKit) app UIs. Focus-free primitives:
-   click / select / right_click / type-into-a-field / `menu` (run a menu-bar command by path —
-   use it INSTEAD of a keyboard shortcut). `key` and `click_xy` STEAL FOCUS and auto-prompt the
-   user — last resort only, when no menu/field/API equivalent exists.
-   EMBEDDED-CHROMIUM apps — Electron (Cursor, VS Code, Discord, Slack, …) or CEF (e.g. Spotify): their
-   UI is web content that Chromium only keeps in the AX tree while active. `snapshot(app)` handles this
-   FOR you — it relaunches the app once, focus-free, with --force-renderer-accessibility so the full
-   tree stays live in the background (a brief one-time blink; the app restores its view). After that,
-   read/act on it like any native app, no focus cost. Real Electron ALSO exposes a CDP debug port, so
-   web_open (layer 3) is an alternative; but hardened apps (Discord) strip that port, and the AX-tree
-   path above works on them anyway. If the app is the user's actively-open editor, prefer NOT to drive
-   it. Only if the tree stays empty even after the force relaunch is the app truly locked — see below.
-
-KEY WORKFLOWS:
-- TOGGLES / CHECKBOXES (System Settings, Accessibility, …): in the tree, `AXCheckBox val='0'` means
-  OFF and `val='1'` means ON — never invent other meanings. Prefer `find` / `snapshot` to locate the
-  control (or its label's sibling checkbox), then `act` click that ref. ALWAYS re-`snapshot` (or read
-  the act delta) and confirm the value flipped before declaring done. Do NOT use `defaults write`,
-  `do shell script`, or AppleScript UI-clicks to flip System Settings — those paths are refused and
-  often write the wrong key while the pane stays unchanged. Sidebar rows (Spotlight, Motion, …): if
-  click reports "no navigation", `select` the row or use the View menu — do not grind the same click.
-- Sign into a site: `web_login(app, url)` opens a background banner-tagged window and uses the
-  configured user-attention notification when enabled; then wait for their "done".
-- Log in with SAVED credentials: if `list_credentials` shows a service, `web_open` the site then
-  `web_fill_login(service)` — Hunch types the saved email+password straight into the page and you
-  NEVER see the values; then submit via `web_act`. No saved credential? Use `web_login` instead.
-- Enter a SAVED API key/secret: `web_fill_secret(service, ref)` types the protected value straight
-  into the given field (ref from `web_snapshot`) — you never see it. Never ask the user to paste a
-  key into chat if a saved secret exists.
-- Page stuck/blank/slow: first WAIT and re-`web_snapshot` (give a heavy page 15-30s). Restart
-  only if it's truly broken (error page / unchanged) via `web_restart` — do NOT grind on it.
-- Page tree shows only NAV/SIDEBAR, main content missing: it's lazy-loaded / below the fold / still
-  hydrating — SCROLL and re-read (`web_act` [{"action":"key","key":"PageDown"}], focus-free via CDP)
-  or wait and `web_snapshot` again. This is NORMAL, not a broken page. NEVER reach for the OS
-  `screenshot` tool to see a web page — it captures the physical frontmost screen, so on a background
-  CDP window you get the USER's own window, not the page. If you truly need the page as pixels
-  (chart/canvas/image), use `web_screenshot` (focus-free, captures the CDP page itself).
-- OPEN A FILE OR FOLDER IN AN APP: `open_file(path, app="Cursor")` — one call, focus-free. NEVER
-  drive a native Open/Save panel (File ▸ Open…). Those panels don't select by AX (the row accepts
-  the write and stays unselected, so the Open button never enables) and their Go-to-Folder sheet
-  needs real keystrokes — it is a guaranteed multi-call dead end. If one is already open on screen,
-  Escape it and use `open_file`.
-- EDITORS ARE MULTI-WINDOW, and every window has the SAME url — only the TITLE names the workspace.
-  `web_open(app="Cursor", url="/abs/folder")` now VERIFIES it reached that folder and says so
-  plainly if it didn't (it will not report a workspace it never reached). Trust that string over
-  the tree: a wrong-workspace window still returns a perfectly valid-looking tree. `web_tabs` lists
-  the windows by workspace; `web_switch_tab(i)` binds another. To move a BOUND window to a
-  different folder, drive it from inside: `web_act` key cmd+shift+p, type ">File: Open Recent",
-  click the row — that keeps the window CDP is attached to.
-- Hunch's CDP-driven Cursor/Chrome is a SEPARATE PROCESS from the user's own copy of that app, on
-  its own profile. `snapshot`/`act` (AX) may read the user's copy while `web_*` drives Hunch's —
-  same name, different windows. A snapshot says so with a `[!]` line when both are running; don't
-  cross the two layers on one app without checking which is which.
-- Drive a code editor's TERMINAL (Cursor / VS Code): the AX tree can READ an integrated terminal
-  but CANNOT type into it — it's xterm.js, which reads real KEYSTROKES, so an AX `type` lands in a
-  screen-reader mirror and silently does nothing (snapshot's set 'succeeds' but the shell never runs
-  it). Use CDP: `web_open(app="Cursor", url="/abs/path/to/folder")` opens a DEDICATED, background
-  Hunch editor window on that folder — SEPARATE from the user's own editor, so it's non-destructive
-  and focus-free. If no terminal is open yet, `web_act` [{"action":"key","key":"`","modifiers":
-  ["ctrl"]}] to open one (it's a toggle — only if the snapshot shows no Terminal). Then `web_snapshot`,
-  find the `[eN] tab "Terminal"` element, and `web_act` "type" ref=eN text="claude agents\n": a
-  TRAILING NEWLINE runs the command in the shell; omit it to stage without running. The dedicated
-  editor profile is fresh on first use — if it shows a sign-in/onboarding wall, treat it like
-  `web_login` (have the user sign into that window once; it persists).
-- You need the human (sign-in, 2FA, a decision, review-before-submit): call `notify_user(msg)`
-  so they get a desktop alert — never stall silently.
-- PERMISSION CLAIMS REQUIRE EXPLICIT EVIDENCE: never infer a missing macOS permission from a
-  timeout, empty AppleScript result, empty/near-empty tree, or an app being slow. A timeout is over
-  (nothing is still running): say it ended, try at most one smaller query, then switch layers. Only
-  tell the user a permission is missing when the tool result explicitly identifies
-  `ACCESSIBILITY_DENIED`, `AUTOMATION_DENIED`, or `FULL_DISK_ACCESS_REQUIRED` (or includes the
-  corresponding explicit macOS denial). Keep those capabilities distinct.
-- MESSAGES HISTORY: do not read `~/Library/Messages/chat.db` or ask for Full Disk Access by default.
-  Full Disk Access is broader than Hunch's normal permissions. Use Messages AppleScript and the AX
-  `snapshot`/`act` path; if the only remaining step needs foreground paging, explain that specific
-  focus requirement and ask through the normal focus gate.
-- APP RESISTS EVERY LAYER: `snapshot` already auto-relaunches an embedded-Chromium app with the
-  accessibility flag, so most Electron/CEF apps DO yield a tree. Only if `snapshot` STILL reads an
-  empty/near-empty tree after that one-time force relaunch (and `web_open` can't attach a debug port)
-  is the app truly locked. Don't grind (no repeated launches/restarts — a restart can also disrupt the
-  user, e.g. interrupt playback). Fall back in order, STAYING NATIVE: (1) its AppleScript dictionary
-  if it has one (media/player apps are commonly PLAYBACK-ONLY — no library/downloads/content control);
-  (2) VISION on the native app — `screenshot` to read the screen, then the gated `click_xy`/`key`
-  actions to drive it (they ask the user before taking the screen; needs Screen Recording). Announce
-  the focus steal, work quickly, restore the user's frontmost app after. (3) The service's website is
-  the LAST resort — only if the user prefers it. Be honest about which path you're on.
-- DOING A TASK ON A WEBSITE (make an account, apply, sign up, book): navigate like a HUMAN, don't
-  guess URLs. 1) `web_open` the site's HOMEPAGE / root domain (e.g. https://a16z.com) — NOT a guessed
-  deep path like /apply or /signup. 2) `web_snapshot` to READ it. 3) Find the real link/button for the
-  goal (Sign up, Log in, Apply, Get started, Menu) in the tree and CLICK it by ref. 4) `web_snapshot`
-  again (new tabs auto-follow) and repeat, working page by page to the actual form. If you can't find
-  the link, scroll (`key` PageDown) or open the nav/menu — NEVER fall back to typing a guessed URL.
-- Filling a form: `web_snapshot`, then `web_act` "type" each field (REPLACES content). For a native
-  `<select>` / combobox, type the option's VISIBLE TEXT into the select's own ref — NEVER click the
-  dropdown or its `<option>` nodes (CDP can't open the OS menu; that thrash burns turns). Then type
-  other fields, submit only if told, and re-`web_snapshot` to confirm.
-- Editing a web canvas (Google Docs/Slides and similar): enable the app's screen-reader support when
-  offered, then use `web_screenshot` for pixels. If the body/object has no ref, click_xy at its
-  screenshot coordinate and immediately `type` WITHOUT a ref (or key/drag). Verify with another
-  web_screenshot. Do not cross into native snapshot/act: that targets a different Chrome process.
-
-DESTRUCTIVE / SHELL / PRIVILEGED OPS:
-- Prefer `trash` (reversible) over `rm`; only empty the Trash when the task truly needs the space
-  back — emptying removes trash's undo.
-- Running shell (`do shell script`): check the exit code and RE-VERIFY the effect (e.g. re-measure
-  freed space). NEVER mask a destructive command with `; echo ok` — echo succeeds even when `rm`
-  fails, so a no-op looks like success.
-- Protected paths (CoreSimulator, /Library/Developer, SIP): admin `rm` hits TCC "Operation not
-  permitted" — don't retry variants; notify the user and have them `sudo` from a Full-Disk-Access
-  Terminal.
-
-RULES:
-- You have 20+ tools across these layers — scan the full set before deciding something's impossible.
-- Focus-free layers (OS-API / AppleScript / CDP / AX-click) never touch the user's screen; use them
-  freely. The focus-stealing actions auto-prompt for approval, so don't fear them — but prefer an
-  alternative (menu action, applescript, or a direct API) whenever one exists.
-- Confirm with the user before any consequential/irreversible action (send, delete, submit, purchase)."""

--- a/src/hunch/policy.py
+++ b/src/hunch/policy.py
@@ -22,11 +22,13 @@ DEFAULT_GATES = {
     "shell": True,                   # applescript() containing 'do shell script'
     "destructive_applescript": True, # delete / send / shut down / empty trash / ...
     "destructive_file": True,        # trash / file_op move / copy (destructive filesystem ops)
+    "app_data_mutation": True,        # generated adapters that rewrite an app's persisted data
 }
 
 CONFIG_KEYS = ["gates.focus_steal", "gates.app_to_front", "gates.shell",
                "gates.destructive_applescript", "gates.destructive_file",
-               "notifications.user_attention", "auto_approve_all"]
+               "gates.app_data_mutation", "notifications.user_attention",
+               "auto_approve_all"]
 
 
 def default_config() -> dict:

--- a/src/hunch/results.py
+++ b/src/hunch/results.py
@@ -1,0 +1,38 @@
+"""Additive detailed receipts; transport acceptance never implies a verified effect."""
+from .errors import HunchError
+
+FIELDS = {"value", "title", "enabled", "selected", "expanded"}
+
+
+def validate_postcondition(condition):
+    if condition is None:
+        return
+    if (not isinstance(condition, dict) or set(condition) != {"ref", "field", "equals"}
+            or not isinstance(condition["ref"], str) or not condition["ref"]
+            or not isinstance(condition["field"], str)
+            or condition["field"] not in FIELDS
+            or not isinstance(condition["equals"], (str, int, float, bool, type(None)))):
+        raise HunchError("postcondition requires ref, field (value/title/enabled/selected/expanded), and scalar equals")
+
+
+def action_receipt(messages, requested, mechanism, target, disturbances, condition=None, read=None):
+    # Compatibility backends return text. Be conservative: only an explicit readback
+    # below may produce verified, never an AX/CDP dispatch success string.
+    blocked = any(any(word in message.lower() for word in (
+        "refused", "skipped", "stale", "error on", "unknown action", "not selectable", "drag needs"))
+                  for message in messages)
+    result = {"status": "blocked" if blocked else "performed_unverified",
+              "mechanism": mechanism, "target": target, "disturbances": disturbances,
+              "requested_actions": requested, "attempted_actions": len(messages),
+              "unattempted_actions": max(0, requested - len(messages)), "actions": messages}
+    if condition is not None and not blocked:
+        try:
+            observed = read(condition["ref"], condition["field"])
+            matched = observed == condition["equals"]
+            result["postcondition"] = {"matched": matched, "ref": condition["ref"], "field": condition["field"]}
+            if matched and len(messages) == requested:
+                result["status"] = "verified"
+                result["verification_scope"] = "requested final field value; not each intermediate action"
+        except Exception as error:
+            result["postcondition"] = {"matched": False, "reason": str(error)}
+    return result

--- a/src/hunch/sdk.py
+++ b/src/hunch/sdk.py
@@ -48,9 +48,8 @@ __all__ = ["Hunch", "HunchError", "ApprovalDenied", "AccessibilityNotGranted",
 
 
 def _frontmost():
-    from AppKit import NSWorkspace
-    app = NSWorkspace.sharedWorkspace().frontmostApplication()
-    return app.localizedName() if app else "Finder"
+    from .local_mac import _frontmost as fresh_frontmost
+    return fresh_frontmost()[0] or "Finder"
 
 
 class Hunch:
@@ -60,7 +59,8 @@ class Hunch:
                  simultaneous=False, cdp_port=None,
                  snapshot_max_depth=None, snapshot_max_nodes=None,
                  provider="claude", auth=None, can_use_tool=None, app_name=None, policy=None,
-                 app_id=None, cdp_profile=None, notify=False):
+                 app_id=None, cdp_profile=None, notify=False, background_only=False,
+                 allow_unrestricted_scripts=False, allowed_web_origins=()):
         """provider: which LLM vendor drives the agent loop — 'claude' (Anthropic, on your
         Claude sign-in; the default) or 'codex' (OpenAI Codex, on a `codex login` session).
         Set once here; then mac.login() / mac.status() / mac.logout() and mac.agent all act
@@ -110,6 +110,10 @@ class Hunch:
         if not (notify is None or isinstance(notify, bool) or callable(notify)):
             raise HunchError("notify must be True, False, None, or a callable(message, title)")
         self.app_id = app_id
+        self._secrets = set()
+        self.background_only = bool(background_only)
+        self.allow_unrestricted_scripts = bool(allow_unrestricted_scripts)
+        self.allowed_web_origins = tuple(allowed_web_origins)
         self._app_id = app_id            # what Agent/_SubscriptionRunner read
         self._notify_handler = notify if callable(notify) else None
         self._native_notifications = notify is True
@@ -137,14 +141,18 @@ class Hunch:
         if check_permissions:
             self._check_accessibility()
         # ONE persistent computer per instance, so element [refs] survive snapshot -> act.
-        self._computer = LocalComputer(app=app, simultaneous=simultaneous,
+        self._computer = LocalComputer(app=app, simultaneous=simultaneous or background_only,
                                        max_depth=snapshot_max_depth,
                                        max_nodes=snapshot_max_nodes)
+        self._computer.session._shared_guard = self._authorize_shared_input
+        from .capabilities import Capabilities
+        self._capabilities = Capabilities(self)
         # Last app aim'd by focus_app / launch_app / snapshot(app=...). Empty
         # snapshot() prefers this over frontmost so a bare snapshot after
         # focus_app("System Settings") does not silently read Cursor.
         self._aimed_app = None
         # Namespaced defaults (names only — same semantics): derived CDP port + profile.
+        auto_cdp_port = cdp_port is None
         if app_id and cdp_port is None:
             import zlib
             cdp_port = 9400 + (zlib.crc32(app_id.encode()) % 500)
@@ -152,9 +160,44 @@ class Hunch:
             import os as _os
             cdp_profile = _os.path.expanduser(f"~/.hunch/apps/{app_id}/chrome-cdp")
         self.web = Web(self, cdp_port or CDP_PORT, profile=cdp_profile)
+        self.web._auto_port = auto_cdp_port
         self.files = Files(self)
         self.clipboard = Clipboard(self)
         self._agent = None   # the agent loop, created lazily so the LLM SDKs stay optional
+
+    # ── generated app operations ─────────────────────────────────────────────
+
+    def _redact(self, value):
+        if isinstance(value, str):
+            for secret in sorted(self._secrets, key=len, reverse=True):
+                value = value.replace(secret, "[REDACTED]")
+            return value
+        if isinstance(value, dict):
+            return {self._redact(k): self._redact(v) for k, v in value.items()}
+        if isinstance(value, (list, tuple)):
+            return [self._redact(v) for v in value]
+        return value
+
+
+
+    def session_summary(self):
+        """Compact reconnect context without element refs or page contents."""
+        import json
+        session = self._computer.session
+        web = self.web._computer
+        evidence = {"requested_app": self._computer.app,
+                    "background_only": self.background_only, "simultaneous": self.simultaneous,
+                    "last_observed_native_identity": getattr(session, "_identity", None),
+                    "cdp": {"app": web.app, "port": web.port,
+                            "renderer": getattr(web.session, "target_id", None)} if web else None,
+                    "recovery_history": self._capabilities.history[-4:],
+                    "instruction": "Revalidate targets before acting. Prior observations do not prove current operation coverage."}
+        return "Hunch session context: " + json.dumps(self._redact(evidence), default=str)
+
+
+
+
+
 
     @staticmethod
     def _check_accessibility():
@@ -181,10 +224,12 @@ class Hunch:
         never silent: capped output ends in an explicit …marker naming the ref to
         expand. max_children raises the per-node sibling cap to page a big list in."""
         if ref is not None:
-            return self._computer.snapshot(ref=ref, max_depth=max_depth, max_nodes=max_nodes,
-                                           max_children=max_children)
+            return self._redact(self._computer.snapshot(ref=ref, max_depth=max_depth, max_nodes=max_nodes,
+                                                        max_children=max_children))
         prev, prev_aimed = self._computer.app, self._aimed_app
         if app:
+            if app != self._computer.app:
+                self._computer.session._selected_window = None
             self._computer.app = app
             self._aimed_app = app
         else:
@@ -194,7 +239,7 @@ class Hunch:
         if isinstance(out, str) and out.startswith("(app '") and "not found" in out:
             # a failed target must not poison later calls
             self._computer.app, self._aimed_app = prev, prev_aimed
-        return out
+        return self._redact(out)
 
     def find(self, role=None, name_contains=None, app="", max_results=20):
         """Search an app's WHOLE accessibility tree (deeper than snapshot shows) and
@@ -203,6 +248,8 @@ class Hunch:
         name_contains matches title/description/value as a substring."""
         prev, prev_aimed = self._computer.app, self._aimed_app
         if app:
+            if app != self._computer.app:
+                self._computer.session._selected_window = None
             self._computer.app = app
             self._aimed_app = app
         elif self._aimed_app:
@@ -210,9 +257,9 @@ class Hunch:
         out = self._computer.find(role=role, name_contains=name_contains, max_results=max_results)
         if isinstance(out, str) and out.startswith("(app '") and "not found" in out:
             self._computer.app, self._aimed_app = prev, prev_aimed
-        return out
+        return self._redact(out)
 
-    def act(self, actions, reason="", confirm=False):
+    def act(self, actions, reason="", confirm=False, detailed=False, postcondition=None):
         """Run UI actions (same dicts as the MCP `act` tool: click/select/right_click/type/
         menu/key/click_xy by ref) and return the updated tree. Focus-stealing actions are
         gated; a user refusal raises ApprovalDenied. StaleRef means re-snapshot.
@@ -227,11 +274,27 @@ class Hunch:
                                          confirm=confirm, reason=reason)
         if blocked:
             raise ApprovalDenied(blocked)
-        return self._computer.act(actions)
+        self._action_approved = bool(confirm)
+        try:
+            if detailed or postcondition is not None:
+                return self._redact(self._computer.act(actions, detailed=detailed, postcondition=postcondition))
+            return self._redact(self._computer.act(actions))
+        finally:
+            self._action_approved = False
+
+    def _authorize_shared_input(self):
+        if self.background_only or self._computer.simultaneous:
+            return "REFUSED: shared input is disabled by the session's background constraint"
+        if getattr(self, "_action_approved", False):
+            return None
+        return gate.check_focus_steal(self._computer, [{"action": "click_xy"}], self._gate,
+                                     reason="the native action requires shared input")
 
     def screenshot(self):
         """The physical screen as PNG bytes (needs Screen Recording permission). Shows the
         FRONTMOST app — for a background CDP page use web.screenshot() instead."""
+        if self._secrets:
+            raise HunchError("screenshot blocked after secret fill; transformed visual disclosure cannot be excluded")
         return base64.b64decode(screenshot_b64())
 
     # ── app lifecycle ─────────────────────────────────────────────────────────
@@ -240,28 +303,52 @@ class Hunch:
         """Names of the running GUI apps you can snapshot()."""
         return list_running_apps()
 
+    def targets(self, app="", window="", select=False, inventory="running"):
+        return self._capabilities.targets(app, window, select, inventory)
+
+    def capabilities(self, app, operation="observe"):
+        return self._capabilities.inspect(app, operation)
+
+    def recover(self, plan_id, target_id=""):
+        return self._capabilities.recover(plan_id, target_id)
+
     def launch_app(self, name, force_accessibility=False, reason=""):
         """Launch or focus an app and target it for snapshots. force_accessibility=True
         relaunches an Electron/Chromium app so its tree becomes readable. A foreground
         launch is a real focus switch: gated — refusal raises ApprovalDenied."""
+        if force_accessibility and self._gate.enabled("app_to_front"):
+            if not self._gate.confirm_dialog(f"Restart {name} gracefully to enable accessibility?",
+                                             category="app_lifecycle", detail=name,
+                                             screen_approval=False):
+                raise ApprovalDenied("user did not approve the accessibility restart")
         if not self._computer.simultaneous:   # foreground launch = a real focus switch
             blocked = self._gate.front_gate(name, reason)
             if blocked:
                 raise ApprovalDenied(blocked)
         set_focus_reason(reason)
         msg = _launch_app(name, force_accessibility, background=self._computer.simultaneous)
+        if force_accessibility:
+            d = self._computer.session.disturbances
+            d["restart_requests"] = d.get("restart_requests", 0) + 1
+            msg += "; disturbance: accessibility restart requested"
+        if msg.startswith(("REFUSED:", "failed")):
+            return msg
         self._computer.app = name
         self._aimed_app = name
         refs = self._computer.snapshot().count("[e")
         return (f"{msg}; accessibility tree has {refs} elements"
-                + ("" if refs > 15 else
-                   " (still low — if it's an Electron app, retry with force_accessibility=True)"))
+                + "; verify the requested operation; node count does not establish coverage")
 
     def quit_app(self, name):
-        return _quit_app(name)
+        message = _quit_app(name)
+        d = self._computer.session.disturbances
+        d["quit_requests"] = d.get("quit_requests", 0) + 1
+        return message + "; disturbance: graceful quit requested"
 
     def focus_app(self, name, reason=""):
         """Bring an app to the front and target it. Gated — refusal raises ApprovalDenied."""
+        if self.background_only:
+            raise ApprovalDenied("host background constraint forbids foreground activation")
         blocked = self._gate.front_gate(name, reason)
         if blocked:
             raise ApprovalDenied(blocked)
@@ -279,6 +366,8 @@ class Hunch:
 
     @simultaneous.setter
     def simultaneous(self, on):
+        if self.background_only and not on:
+            raise ApprovalDenied("host background constraint cannot be disabled by a tool")
         self._computer.simultaneous = bool(on)
 
     # ── AppleScript / OS ──────────────────────────────────────────────────────
@@ -289,6 +378,8 @@ class Hunch:
         confirm=True skips the dialog (the user already approved out-of-band).
         System Settings toggles via defaults write / UI scripting are soft-refused with a
         teaching string — AX snapshot/act is the reliable path."""
+        if self.background_only and not self.allow_unrestricted_scripts:
+            return "REFUSED: arbitrary AppleScript has no enforceable background guarantee; use a typed operation"
         refusal = gate.applescript_settings_refusal(script)
         if refusal:
             return refusal
@@ -302,8 +393,8 @@ class Hunch:
                 raise ApprovalDenied("user did not approve the AppleScript")
         ok, out = os_ops.run_applescript(script)
         if ok:
-            hint = "" if out else gate.applescript_empty_hint(script)
-            return f"(no output){hint}" if hint else out
+            hint = gate.applescript_empty_hint(script) if out.strip() in ("", "0") else ""
+            return f"{out or '(no output)'}{hint}"
         return f"AppleScript error: {out[:600]}{gate.applescript_hint(out, script)}"
 
     def notify(self, message, title=None):
@@ -386,22 +477,72 @@ class Hunch:
 
 class Web:
     """Focus-free browser/Electron control over CDP, on a persistent profile. With no
-    app_id the port/profile are the shared personal ones (whichever process opened the
-    browser first is gracefully reused); with an app_id each app gets its OWN port and
-    profile, so restart()/login() recovery can only ever kill that app's browser."""
+    app_id the profile defaults to the personal Hunch profile; namespaced hosts get their
+    own profile. Default ports are allocated at launch. Only the launching SDK instance
+    owns lifecycle recovery; explicit attachment never grants ownership."""
 
     def __init__(self, hunch, port, profile=None):
         self._h = hunch
+        self._owner = object()
         self.port = port
         self.profile = profile      # None -> cdp.HUNCH_PROFILE (the personal default)
         self.force_sandbox = None   # True forces isolated profiles; None defers to
                                     #   the HUNCH_FORCE_SANDBOX env var (the app toggle)
         self._computer = None       # per-instance CDPComputer (the server's _cdp equivalent)
 
+    @property
+    def port(self):
+        return self._port
+
+    @port.setter
+    def port(self, value):
+        self._port = value
+        self._auto_port = False
+
+    def _launch_port(self):
+        if getattr(self, "_auto_port", False):
+            from .cdp import _OWNED_ENDPOINTS
+            if _OWNED_ENDPOINTS.get(self.port, {}).get("owner") is not self._owner:
+                import socket
+                with socket.socket() as listener:
+                    listener.bind(("127.0.0.1", 0))
+                    self._port = listener.getsockname()[1]
+        return self.port
+
     def _session(self):
         if self._computer is None:
             raise WebNotOpen("no web/Electron app open — call web_open / web.open() first")
+        identity = getattr(self._computer, "identity", None)
+        if identity:
+            from .cdp import endpoint_identity
+            from .targets import process_key
+            if process_key(endpoint_identity(self._computer.port)) != process_key(identity):
+                raise HunchError("CDP owning process changed; attach again")
         return self._computer.session
+
+    def attach(self, app, port, target_id="", *, expected_identity=None):
+        """Attach to an existing verified local endpoint without launching or quitting."""
+        from .cdp import CDPComputer, CDPSession, verify_endpoint
+        identity = verify_endpoint(port, app)
+        from .targets import process_key
+        if expected_identity is not None and process_key(identity) != process_key(expected_identity):
+            raise HunchError("CDP endpoint belongs to a different process; inspect capabilities again")
+        session = CDPSession(port)
+        pages = session._list_page_targets()
+        matches = [p for p in pages if p.get("id") == target_id] if target_id else pages
+        if len(matches) != 1:
+            return {"status": "blocked", "reason": "select a renderer target_id", "targets": [
+                {"id": p.get("id"), "title": p.get("title"), "url": p.get("url")} for p in pages]}
+        session._open_ws(matches[0])
+        session._known_targets = {p.get("id") for p in pages}
+        session.pinned_app = True
+        session.allowed_origins = self._h.allowed_web_origins
+        self.close()
+        computer = CDPComputer(app, port=port, connect=False)
+        computer.session, computer.identity = session, identity
+        self._computer = computer
+        return {"status": "verified", "scope": "endpoint attachment; requested UI effect unverified",
+                "target": identity, "renderer": session.target_id}
 
     def open(self, url="", app="Google Chrome", isolated=False):
         """Open a Chromium browser (or Electron app) for focus-free control. Uses the
@@ -416,6 +557,11 @@ class Web:
         from .cdp import _is_editor
         if _is_editor(app):
             return self._open_editor(folder=url, app=app)
+        if url:
+            from .destinations import navigation_refusal
+            refusal = navigation_refusal(url, self._h.allowed_web_origins)
+            if refusal:
+                return refusal
         import os as _os
         force = (self.force_sandbox if self.force_sandbox is not None
                  else _os.environ.get("HUNCH_FORCE_SANDBOX") == "1")
@@ -424,15 +570,18 @@ class Web:
         from .cdp import CDPComputer
         self.close()
         try:
-            self._computer = CDPComputer(app, port=self.port, url=url or None,
+            self._computer = CDPComputer(app, port=self._launch_port(), url=url or None,
                                          isolated=isolated, background=True,
-                                         profile=self.profile)
+                                         profile=self.profile, allowed_origins=self._h.allowed_web_origins,
+                                         owner=self._owner)
         except Exception as e:   # e.g. debug port never bound, or a page-less stale instance
             raise HunchError(f"couldn't open {app} over CDP: {e} — "
                              "web.restart() recovers a stale instance") from e
         s = self._computer.session
         if url:
-            s.navigate(url)
+            navigation = s.navigate(url)
+            if navigation and not navigation.startswith("navigated"):
+                return navigation
         s.wait_ready()
         if not isolated and s.signed_out():
             return (f"opened {app} over CDP, but the Hunch profile isn't signed in "
@@ -449,6 +598,10 @@ class Web:
         import os as _os
         from .cdp import CDPComputer, editor_target, open_folder_in_editor
         port, profile, real = editor_target(app)
+        if getattr(self, "_auto_port", False):
+            port = self._launch_port()
+        if self._h.app_id or self.profile:
+            port, profile = self.port, self.profile
         # Check the path BEFORE launching anything: a typo'd folder otherwise costs a launch plus
         # ~40s of polling for a window that can never appear, and ends in a vague failure.
         if folder and not _os.path.exists(_os.path.expanduser(folder)):
@@ -460,7 +613,7 @@ class Web:
         try:
             self._computer = CDPComputer(real, port=port, url=folder or None,
                                          isolated=False, background=True, profile=profile,
-                                         editor=True)
+                                         editor=True, owner=getattr(self, "_owner", None))
         except Exception as e:
             raise HunchError(f"couldn't open {real} over CDP: {e} — "
                              "web.restart() recovers a stale instance") from e
@@ -509,18 +662,29 @@ class Web:
         """Open a background, banner-tagged window for the HUMAN to sign in once (Hunch
         never sees the password). Uses the configured user-attention notification, if
         enabled; the login persists in the Hunch profile."""
-        from .cdp import CDPComputer, quit_cdp
-        self.close()
-        quit_cdp(self.port)  # fresh window, no stale-instance reuse
-        try:
-            self._computer = CDPComputer(app, port=self.port, url=url or None,
-                                         isolated=False, background=True,
-                                         profile=self.profile)
-        except Exception as e:
-            raise HunchError(f"couldn't open {app} for login: {e}") from e
-        s = self._computer.session
+        from .cdp import CDPComputer
         if url:
-            s.navigate(url)
+            from .destinations import navigation_refusal
+            refusal = navigation_refusal(url, self._h.allowed_web_origins)
+            if refusal:
+                return refusal
+        if self._computer is not None:
+            s = self._session()
+            if self._computer.editor and url:
+                return "REFUSED: editor login retains its workspace; use the editor's sign-in controls"
+        else:
+            try:
+                self._computer = CDPComputer(app, port=self._launch_port(), url=url or None,
+                                             isolated=False, background=True,
+                                             profile=self.profile, allowed_origins=self._h.allowed_web_origins,
+                                             owner=self._owner)
+            except Exception as e:
+                raise HunchError(f"couldn't open {app} for login: {e}") from e
+            s = self._computer.session
+        if url:
+            navigation = s.navigate(url)
+            if navigation and not navigation.startswith("navigated"):
+                return navigation
         s.wait_ready()
         s.mark()
         notified = self._h.notify(
@@ -532,19 +696,38 @@ class Web:
 
     def restart(self, url="", app="Google Chrome"):
         """Quit and reopen the CDP instance fresh (same persistent profile, login kept).
-        Last resort for a truly broken page — kills whatever holds the CDP port."""
+        Refuses to restart a process launched by another SDK instance."""
         from .cdp import CDPComputer, quit_cdp
+        current = self._computer
+        if current is None:
+            raise WebNotOpen("no owned CDP session to restart; use web.open or attach")
+        app, port = current.app, current.port
+        from .cdp import _OWNED_ENDPOINTS
+        owned = _OWNED_ENDPOINTS.get(port)
+        if not owned or owned.get("owner") is not self._owner:
+            raise HunchError("attached external session is not owned; use explicit app recovery")
+        profile = owned["profile"]
+        editor = current.editor
+        folder = getattr(current.session, "pinned", None)
+        if url and not editor:
+            from .destinations import navigation_refusal
+            refusal = navigation_refusal(url, self._h.allowed_web_origins)
+            if refusal:
+                return refusal
+        quit_cdp(port, owner=self._owner)
         self.close()
-        quit_cdp(self.port)
         try:
-            self._computer = CDPComputer(app, port=self.port, url=url or None,
-                                         isolated=False, background=True,
-                                         profile=self.profile)
+            self._computer = CDPComputer(app, port=port, url=folder if editor else url or None,
+                                         isolated=False, background=True, editor=editor,
+                                         profile=profile, allowed_origins=self._h.allowed_web_origins,
+                                         owner=self._owner)
         except Exception as e:
             raise HunchError(f"couldn't reopen {app} over CDP: {e}") from e
         s = self._computer.session
-        if url:
-            s.navigate(url)
+        if url and not editor:
+            navigation = s.navigate(url)
+            if navigation and not navigation.startswith("navigated"):
+                return navigation
         s.wait_ready()
         snap = self._computer.snapshot()
         return f"restarted {app} over CDP ({snap.count('[e')} elements)"
@@ -552,16 +735,20 @@ class Web:
     def snapshot(self):
         """The current page as a ref-annotated accessibility tree (focus-free)."""
         self._session()
-        return self._computer.snapshot()
+        return self._h._redact(self._computer.snapshot())
 
-    def act(self, actions):
+    def act(self, actions, detailed=False, postcondition=None):
         """Page actions: click by ref; click_xy/drag at web-screenshot coordinates; type
         (replaces a referenced field, or types at focus without a ref); key; navigate."""
         self._session()
-        return self._computer.act(actions)
+        if detailed or postcondition is not None:
+            return self._h._redact(self._computer.act(actions, detailed=detailed, postcondition=postcondition))
+        return self._h._redact(self._computer.act(actions))
 
     def screenshot(self):
         """The CDP page itself as PNG bytes (focus-free — works in the background)."""
+        if self._h._secrets:
+            raise HunchError("screenshot blocked after secret fill; text redaction does not protect pixels")
         data = self._session().capture_screenshot()
         if not data:
             raise HunchError("could not capture the page")
@@ -591,17 +778,19 @@ class Web:
 
     def fill_login(self, service):
         """Fill the current page's login form from the user's saved Keychain credential.
-        The values never enter your program: read here, typed into the page, deleted.
+        Values stay in the SDK process and destination page; outputs redact known values.
         Domain-bound credentials are refused on other sites (returns a REFUSED string)."""
         s = self._session()
         ns = self._h.app_id
-        from .creds import get_credential, has, kind_of
+        from .creds import get_credential, has, kind_of, domains_of
         if not has(service, ns):
             return (f"No saved credential for '{service}'. See list_credentials(), or add "
                     f"one with: hunch creds add {service}")
         if kind_of(service, ns) == "secret":
             return (f"'{service}' is a protected value (API key/token), not a login — use "
                     f"web.fill_secret('{service}', ref) instead.")
+        if not domains_of(service, ns):
+            return "REFUSED: credential has no destination binding; run hunch creds bind SERVICE --domain DOMAIN or use interactive login"
         blocked = gate.domain_mismatch(service, self._page_url(),
                                        app_name=self._h.app_name, namespace=ns)
         if blocked:
@@ -609,23 +798,32 @@ class Web:
         username, password = get_credential(service, ns)   # stays in this process; never returned
         if not (username or password):
             return f"Couldn't read the '{service}' credential from the Keychain."
-        r = s.fill_login(username, password)
+        self._h._secrets.update(v for v in (username, password) if v)
+        self._session()
+        blocked = gate.domain_mismatch(service, self._page_url(), app_name=self._h.app_name, namespace=ns)
+        if blocked:
+            return blocked
+        r = s.fill_login(username, password, expected_url=self._page_url())
         del username, password
+        if not (r["username_filled"] or r["password_filled"]):
+            return "UNVERIFIED: no login field was verified on the bound destination"
         return (f"filled '{service}': username={r['username_filled']}, "
                 f"password={r['password_filled']} (values not returned)")
 
     def fill_secret(self, service, ref=""):
         """Type the saved protected value (API key/token) for `service` into a field by ref
-        (or the focused element). The value never enters your program."""
+        (or the focused form input). Values stay in the SDK process and destination page."""
         s = self._session()
         ns = self._h.app_id
-        from .creds import has, kind_of, get_secret
+        from .creds import has, kind_of, get_secret, domains_of
         if not has(service, ns):
             return (f"No saved credential for '{service}'. See list_credentials(), or add "
                     f"one with: hunch creds add {service} --secret")
         if kind_of(service, ns) != "secret":
             return (f"'{service}' is a username+password login — use "
                     f"web.fill_login('{service}') instead.")
+        if not domains_of(service, ns):
+            return "REFUSED: credential has no destination binding; run hunch creds bind SERVICE --domain DOMAIN or use interactive login"
         blocked = gate.domain_mismatch(service, self._page_url(),
                                        app_name=self._h.app_name, namespace=ns)
         if blocked:
@@ -633,8 +831,15 @@ class Web:
         secret = get_secret(service, ns)   # stays in this process; never returned
         if not secret:
             return f"Couldn't read the '{service}' secret from the Keychain."
-        s.type_text(ref or None, secret)
+        self._h._secrets.add(secret)
+        self._session()
+        blocked = gate.domain_mismatch(service, self._page_url(), app_name=self._h.app_name, namespace=ns)
+        if blocked:
+            return blocked
+        result = s.fill_secret(ref or None, secret, self._page_url())
         del secret
+        if not result:
+            return "UNVERIFIED: secret fill did not verify a writable form input on the bound destination"
         return (f"filled the '{service}' secret into "
                 f"{('field ' + ref) if ref else 'the focused element'} (value not returned)")
 
@@ -727,7 +932,14 @@ class Files:
 
     def reveal(self, paths):
         """Reveal item(s) in Finder (this one does bring Finder forward)."""
-        return os_ops.reveal(paths)
+        if self._h.background_only or self._h.simultaneous:
+            raise ApprovalDenied("revealing files fronts Finder; background mode forbids it")
+        blocked = self._h._gate.front_gate("Finder", "reveal selected files")
+        if blocked:
+            raise ApprovalDenied(blocked)
+        result = os_ops.reveal(paths)
+        self._h._computer.session.disturbances["app_raises"] += 1
+        return result + "; disturbance: Finder reveal requested"
 
 
 class Clipboard:
@@ -738,4 +950,7 @@ class Clipboard:
         return os_ops.clipboard_read()
 
     def set(self, text):
-        return os_ops.clipboard_write(text)
+        result = os_ops.clipboard_write(text)
+        disturbances = self._h._computer.session.disturbances
+        disturbances["clipboard_changes"] = disturbances.get("clipboard_changes", 0) + 1
+        return result + "; disturbance: shared clipboard changed"

--- a/src/hunch/server.py
+++ b/src/hunch/server.py
@@ -62,8 +62,14 @@ _mac = Hunch(
     # that forgot inherited an agent free to grab the user's cursor. Making it
     # settable at startup lets the operator, not the model, own that promise.
     simultaneous=bool(os.environ.get("HUNCH_SIMULTANEOUS")),
+    background_only=bool(os.environ.get("HUNCH_BACKGROUND_ONLY")),
 )
+if os.environ.get("HUNCH_RUNTIME_CONFIG"):
+    import json
+    _config = json.loads(os.environ["HUNCH_RUNTIME_CONFIG"])
+    _mac = Hunch(check_permissions=False, **_config)
 _gate = _mac._gate            # single Gate: approval state behaves as the old module globals
+mcp._mcp_server.instructions = HUNCH_PLAYBOOK + "\n" + _mac.session_summary()
 _as_str = gate.as_str         # kept aliases (tests + external callers)
 _protected = gate.protected
 _HUNCH_DIR = gate.HUNCH_DIR
@@ -124,7 +130,7 @@ def find(role: str = "", name_contains: str = "", app: str = "", max_results: in
 
 
 @mcp.tool()
-def act(actions: list, reason: str = "") -> str:
+def act(actions: list, reason: str = "", detailed: bool = False, postcondition: dict | None = None) -> str | dict:
     """Execute one or more UI actions in order (by element ref), then return what
     CHANGED on screen since your last view (~ changed, + new, gone: refs; unchanged
     lines omitted). First look, a window change, or heavy churn returns the full
@@ -166,7 +172,7 @@ def act(actions: list, reason: str = "") -> str:
     When the batch contains ANY focus-stealing action, ALWAYS pass `reason` — one short human
     sentence for WHY you need the screen (e.g. "press Enter to submit the search"). It is shown
     to the user in the focus warning and the approval prompt."""
-    return _run("act", actions=actions, reason=reason)
+    return _run("act", actions=actions, reason=reason, detailed=detailed, postcondition=postcondition)
 
 
 @mcp.tool()
@@ -206,8 +212,8 @@ def simultaneous_mode(on: bool = True) -> str:
     or switches your view: it reads apps WITHOUT bringing them forward, launches apps in
     the background, runs only the focus-free actions (click/select/set-a-field by ref),
     and REFUSES shared-input actions (typed keystrokes, key combos, pixel clicks) that
-    would disrupt you. Works for native apps; Electron apps read empty in this mode
-    (they need to be frontmost). Turn OFF to let Hunch bring apps forward and use the
+    would disrupt you. Background AX coverage is operation- and state-dependent,
+    including in Electron apps. Turn OFF to let Hunch bring apps forward and use the
     full input set (for when you're away from the machine)."""
     return _run("simultaneous_mode", on=on)
 
@@ -293,7 +299,7 @@ def web_screenshot() -> Image:
 
 
 @mcp.tool()
-def web_act(actions: list) -> str:
+def web_act(actions: list, detailed: bool = False, postcondition: dict | None = None) -> str | dict:
     """Execute focus-free page actions on the CDP-controlled app, then return the updated tree.
     Each: {"action":"click","ref":"e12"} | {"action":"type","ref":"e12","text":"hi"} |
     {"action":"click_xy","x":500,"y":250} | {"action":"drag","from_x":10,"from_y":20,
@@ -308,7 +314,7 @@ def web_act(actions: list) -> str:
     To follow a link, CLICK it by ref — do NOT `navigate` to a guessed/constructed URL; only
     navigate to a URL the user gave you or that you read from the page (navigate refuses a host
     that doesn't resolve)."""
-    return _run("web_act", actions=actions)
+    return _run("web_act", actions=actions, detailed=detailed, postcondition=postcondition)
 
 
 @mcp.tool()
@@ -459,6 +465,36 @@ def applescript(script: str) -> str:
     report missing permissions when the result explicitly says ACCESSIBILITY_DENIED,
     AUTOMATION_DENIED, or FULL_DISK_ACCESS_REQUIRED."""
     return _run("applescript", script=script)
+
+
+# Register before the module entry point starts the blocking server.
+@mcp.tool()
+def app_target(app: str = "", window: str = "", select: bool = False, inventory: str = "running") -> dict:
+    return _run("app_target", app=app, window=window, select=select, inventory=inventory)
+
+
+@mcp.tool()
+def app_capabilities(app: str, operation: str = "observe") -> dict:
+    return _run("app_capabilities", app=app, operation=operation)
+
+
+@mcp.tool()
+def app_recover(plan_id: str, target_id: str = "") -> dict:
+    return _run("app_recover", plan_id=plan_id, target_id=target_id)
+
+
+
+# The model-visible contract comes from one catalog, including descriptions.
+from .tool_registry import catalog
+_catalog_mode = "runtime"
+_definitions = {t["name"]: t for t in catalog(_catalog_mode)}
+for _name in list(mcp._tool_manager._tools):
+    if _name not in _definitions:
+        mcp._tool_manager.remove_tool(_name)
+    else:
+        _tool = mcp._tool_manager._tools[_name]
+        _tool.parameters = _definitions[_name]["input_schema"]
+        _tool.description = _definitions[_name]["description"]
 
 
 def main():

--- a/src/hunch/targets.py
+++ b/src/hunch/targets.py
@@ -1,0 +1,130 @@
+"""Session target identity and selection, independent of AX transport calls."""
+import os
+import plistlib
+from dataclasses import dataclass
+from functools import lru_cache
+
+from .errors import HunchError
+
+
+class TargetError(HunchError):
+    pass
+
+
+def normalize_name(value):
+    for cp in (0x200E, 0x200F, 0x200B, 0x200C, 0x200D, 0xFEFF,
+               0x202A, 0x202B, 0x202C, 0x202D, 0x202E):
+        value = value.replace(chr(cp), "")
+    return value.strip().casefold()
+
+
+def select_running(query, candidates):
+    """Resolve exactly one process; even exact bundle/path matches may be ambiguous."""
+    query = str(query)
+    if query.startswith("pid:"):
+        matches = [a for a in candidates if str(a["pid"]) == query[4:]]
+    elif query.startswith(("/", "~")):
+        path = os.path.realpath(os.path.expanduser(query))
+        matches = [a for a in candidates if a.get("path") and os.path.realpath(a["path"]) == path]
+    else:
+        matches = [a for a in candidates if a.get("bundle_id") == query]
+        if not matches:
+            name = normalize_name(query)
+            matches = [a for a in candidates if normalize_name(a.get("name", "")) == name]
+            if not matches and name:
+                matches = [a for a in candidates if name in normalize_name(a.get("name", ""))]
+    if len(matches) > 1:
+        choices = "; ".join(f"pid:{a['pid']} {a.get('path') or a.get('name')}" for a in matches)
+        raise TargetError(f"ambiguous app {query!r}; select an exact process: {choices}")
+    return matches[0] if matches else None
+
+
+def process_key(identity):
+    return (identity.get("pid"), identity.get("started_at"), identity.get("path"),
+            identity.get("bundle_id"), identity.get("version"), identity.get("build"))
+
+
+@lru_cache(maxsize=128)
+def _bundle_metadata(path, modified):
+    with open(path, "rb") as source:
+        info = plistlib.load(source)
+    return {"version": str(info.get("CFBundleShortVersionString", "")),
+            "build": str(info.get("CFBundleVersion", ""))}
+
+
+def bundle_metadata(app_path):
+    path = os.path.join(app_path, "Contents", "Info.plist")
+    try:
+        return _bundle_metadata(path, os.stat(path).st_mtime_ns)
+    except (OSError, ValueError, plistlib.InvalidFileException):
+        return {}
+
+
+def installed_apps(query="", roots=None, limit=500):
+    """Bounded bundle inventory, kept separate from running-process identity."""
+    roots = roots or ("/Applications", "/System/Applications", os.path.expanduser("~/Applications"))
+    entries, seen = [], set()
+    query = normalize_name(query)
+    for root in roots:
+        for directory, children, _ in os.walk(root, followlinks=False):
+            relative = os.path.relpath(directory, root)
+            depth = 0 if relative == "." else len(relative.split(os.sep))
+            bundles = sorted(name for name in children if name.endswith(".app"))
+            children[:] = sorted(name for name in children if not name.endswith(".app")) if depth < 3 else []
+            for name in bundles:
+                path = os.path.realpath(os.path.join(directory, name))
+                if path in seen:
+                    continue
+                seen.add(path)
+                try:
+                    with open(os.path.join(path, "Contents", "Info.plist"), "rb") as source:
+                        info = plistlib.load(source)
+                    entry = {"name": str(info.get("CFBundleDisplayName") or info.get("CFBundleName") or name[:-4]),
+                             "path": path, "bundle_id": str(info.get("CFBundleIdentifier", "")),
+                             **bundle_metadata(path)}
+                except (OSError, ValueError, plistlib.InvalidFileException):
+                    continue
+                if not query or any(query in normalize_name(entry[key]) for key in ("name", "path", "bundle_id")):
+                    entries.append(entry)
+                if len(seen) >= limit:
+                    return {"installed": entries, "bounded": True, "truncated": True, "scanned": len(seen)}
+    return {"installed": entries, "bounded": True, "truncated": False, "scanned": len(seen)}
+
+
+@dataclass
+class WindowTarget:
+    handle: str
+    element: object
+    provenance: list
+    generation: int
+
+
+class TargetRegistry:
+    """Opaque window handles last only for the lifetime of their process identity."""
+    def __init__(self):
+        self.identity = None
+        self.windows = []
+        self.generation = 0
+        self._next = 0
+
+    def bind(self, identity, observations):
+        if self.identity is None or process_key(self.identity) != process_key(identity):
+            self.windows = []
+            self.generation += 1
+        self.identity = dict(identity)
+        current = []
+        for element, provenance in observations[:64]:
+            target = next((w for w in self.windows if w.element == element), None)
+            if target is None:
+                self._next += 1
+                target = WindowTarget(f"w{self._next}", element, provenance, self.generation)
+            target.provenance = provenance
+            current.append(target)
+        self.windows = current
+        return current
+
+    def window(self, handle):
+        match = next((w for w in self.windows if w.handle == handle), None)
+        if match is None:
+            raise TargetError(f"window {handle!r} is unavailable or stale; inspect targets again")
+        return match

--- a/src/hunch/tool_registry.py
+++ b/src/hunch/tool_registry.py
@@ -1,0 +1,232 @@
+"""Canonical public schemas and catalog membership for every Hunch transport."""
+_ACTION_ITEM = {
+    "type": "object",
+    "properties": {
+        "action": {"type": "string",
+                   "enum": ["click", "right_click", "select", "type", "menu", "key", "window", "drag", "click_xy"]},
+        "ref": {"type": "string"}, "text": {"type": "string"},
+        "path": {"type": "array", "items": {"type": "string"}},
+        "key": {"type": "string"}, "modifiers": {"type": "array", "items": {"type": "string"}},
+        "x": {"type": "integer"}, "y": {"type": "integer"}, "w": {"type": "integer"}, "h": {"type": "integer"},
+        "app": {"type": "string"},
+        "from_ref": {"type": "string"}, "to_ref": {"type": "string"},
+        "from_x": {"type": "integer"}, "from_y": {"type": "integer"},
+        "to_x": {"type": "integer"}, "to_y": {"type": "integer"}},
+    "required": ["action"]}
+
+# The web/CDP action item. Its coordinates are renderer-local and focus-free, unlike native pixels.
+_WEB_ACTION_ITEM = {
+    "type": "object",
+    "properties": {
+        "action": {"type": "string", "enum": ["click", "click_xy", "drag", "type", "key", "navigate"]},
+        "ref": {"type": "string"}, "text": {"type": "string"},
+        "key": {"type": "string"}, "modifiers": {"type": "array", "items": {"type": "string"}},
+        "url": {"type": "string"}, "x": {"type": "number"}, "y": {"type": "number"},
+        "from_x": {"type": "number"}, "from_y": {"type": "number"},
+        "to_x": {"type": "number"}, "to_y": {"type": "number"}},
+    "required": ["action"]}
+
+
+def _obj(props=None, required=None):
+    return {"type": "object", "properties": props or {}, "additionalProperties": False,
+            **({"required": required} if required else {})}
+
+
+# Names identical to the MCP tools so every HUNCH_PLAYBOOK reference resolves. Descriptions
+# are condensed (the deep procedural guidance lives in the playbook system prompt); each keeps
+# the prescriptive when-to-call sentence, which measurably lifts should-call rate on Opus.
+BASE_TOOLS = [
+    {"name": "snapshot",
+     "description": ("See an app as an accessibility tree ([ref] per element) — your primary way "
+                     "to read UI focus-free. Pass an app name or leave blank for the frontmost. "
+                     "ref='e42' re-walks just that element's subtree; truncated trees end in `…` "
+                     "markers naming what was dropped."),
+     "input_schema": _obj({"app": {"type": "string"}, "ref": {"type": "string"},
+                           "max_depth": {"type": "integer"}, "max_nodes": {"type": "integer"},
+                           "max_children": {"type": "integer"}})},
+    {"name": "find",
+     "description": ("Search an app's WHOLE tree for matching elements without reading a full "
+                     "snapshot — the cheap way to locate one control in a big window. Filter by "
+                     "role (e.g. 'button', case-insensitive) and/or name_contains (substring of "
+                     "title/description/value). Returns actable [ref]s."),
+     "input_schema": _obj({"role": {"type": "string"}, "name_contains": {"type": "string"},
+                           "app": {"type": "string"}, "max_results": {"type": "integer"}})},
+    {"name": "act",
+     "description": ("Run UI actions in order by ref, then get what CHANGED on screen (unchanged lines omitted; snapshot gives the full tree). To tile/position a window use the 'window' verb (x/y/w/h, focus-free, targets the main window; pass `app` to target a specific app — to tile TWO apps give each window action its own `app`, e.g. app:'TextEdit' x:0 then app:'Notes' x:756). Verbs: click "
+                     "(activate), right_click (context menu), select (highlight a row), type (set "
+                     "a field by ref = focus-free; no ref types at focus = STEALS FOCUS), menu "
+                     "(invoke a menu-bar path, e.g. ['File','Move to Trash'] — the focus-free "
+                     "stand-in for ⌘-shortcuts), key/click_xy (STEAL FOCUS, last resort). Prefer "
+                     "the focus-free verbs. Pass `reason` when any action steals focus."),
+     "input_schema": _obj({"actions": {"type": "array", "items": _ACTION_ITEM},
+                           "reason": {"type": "string"}}, ["actions"])},
+    {"name": "screenshot",
+     "description": ("See the frontmost app as a PNG — only for genuinely visual content the tree "
+                     "can't convey (an image, a chart). To read UI text or check an action, "
+                     "re-snapshot instead. Image pixels are in point space, so a coordinate read "
+                     "here can go straight to a click_xy action."),
+     "input_schema": _obj()},
+    {"name": "list_apps", "description": "List the running GUI apps you can target with snapshot.",
+     "input_schema": _obj()},
+    {"name": "launch_app",
+     "description": ("Launch or focus an app (reliable OS call — beats clicking the Dock). Set "
+                     "force_accessibility=true for an Electron/Chromium app whose tree reads empty. "
+                     "In simultaneous mode it launches in the background."),
+     "input_schema": _obj({"name": {"type": "string"},
+                           "force_accessibility": {"type": "boolean"},
+                           "reason": {"type": "string"}}, ["name"])},
+    {"name": "simultaneous_mode",
+     "description": ("Toggle simultaneous mode. ON = never steal the user's cursor/keyboard/view "
+                     "(background reads, focus-free actions only, shared-input actions refused). "
+                     "OFF = may bring apps forward and use the full input set."),
+     "input_schema": _obj({"on": {"type": "boolean"}})},
+    {"name": "quit_app", "description": "Quit an app via the OS (reliable regardless of focus).",
+     "input_schema": _obj({"name": {"type": "string"}}, ["name"])},
+    {"name": "focus_app",
+     "description": ("Bring an app to the front and target it. This switches the user's view — "
+                     "always pass `reason` (one short sentence for why)."),
+     "input_schema": _obj({"name": {"type": "string"}, "reason": {"type": "string"}}, ["name"])},
+    {"name": "web_open",
+     "description": ("Open a Chromium browser or Electron app for FOCUS-FREE control over CDP — "
+                     "the way to drive web/Electron apps in the background. `app` is the browser "
+                     "(default 'Google Chrome'); put a website in `url`. Uses the persistent Hunch "
+                     "profile; call web_login once if it isn't signed in. CODE EDITORS: app="
+                     "'Cursor'/'Visual Studio Code'/'VSCodium'/'Windsurf' with the FOLDER/FILE in "
+                     "`url` opens a dedicated background editor window whose integrated TERMINAL you "
+                     "can type into (AX can't write it) — snapshot, then web_act 'type' on the "
+                     "'Terminal' tab (trailing newline runs the command); key ctrl+` opens one."),
+     "input_schema": _obj({"app": {"type": "string"}, "url": {"type": "string"},
+                           "isolated": {"type": "boolean"}})},
+    {"name": "web_login",
+     "description": ("Open a background, banner-tagged window for the HUMAN to sign in once (Hunch "
+                     "never sees the password); the login then persists. Uses the configured "
+                     "user-attention notification when enabled."),
+     "input_schema": _obj({"app": {"type": "string"}, "url": {"type": "string"}})},
+    {"name": "web_snapshot",
+     "description": "Read the CDP-controlled page as an accessibility tree. Call web_open first.",
+     "input_schema": _obj()},
+    {"name": "web_screenshot",
+     "description": ("PNG of the CDP page itself (focus-free) — for visual web content the tree "
+                     "can't convey. Use this, never the OS screenshot, for the background browser."),
+     "input_schema": _obj()},
+    {"name": "web_act",
+     "description": ("Run focus-free page actions, then get the updated tree. Verbs: click (by ref), "
+                     "click_xy/drag (coordinates from web_screenshot; canvas editors), type "
+                     "(with ref REPLACES a field; without ref types at current focus), key, navigate "
+                     "(only to a URL you were given or read from the page — click links, don't guess)."),
+     "input_schema": _obj({"actions": {"type": "array", "items": _WEB_ACTION_ITEM}}, ["actions"])},
+    {"name": "web_restart",
+     "description": ("Recover a BROKEN CDP browser by quitting and reopening it fresh (login kept). "
+                     "Last resort — don't restart a merely-slow page; wait and re-snapshot first."),
+     "input_schema": _obj({"app": {"type": "string"}, "url": {"type": "string"}})},
+    {"name": "web_tabs",
+     "description": "List the open CDP tabs (index, title, URL, which is current).",
+     "input_schema": _obj()},
+    {"name": "web_switch_tab",
+     "description": "Switch the CDP session to a tab by index (see web_tabs), then web_snapshot.",
+     "input_schema": _obj({"index": {"type": "integer"}}, ["index"])},
+    {"name": "list_credentials",
+     "description": ("List the service NAMES the user saved credentials for (names + kind only, "
+                     "never values). Fill them with web_fill_login / web_fill_secret."),
+     "input_schema": _obj()},
+    {"name": "web_fill_login",
+     "description": ("Fill the current CDP page's login form from the user's saved credential for "
+                     "`service`, WITHOUT the values entering your context — you only learn which "
+                     "fields were filled. Then submit via web_act. web_open first."),
+     "input_schema": _obj({"service": {"type": "string"}}, ["service"])},
+    {"name": "web_fill_secret",
+     "description": ("Type the user's saved protected value (API key/token) for `service` into a "
+                     "field on the current CDP page, WITHOUT the value entering your context. "
+                     "web_snapshot first and pass the field's ref."),
+     "input_schema": _obj({"service": {"type": "string"}, "ref": {"type": "string"}}, ["service"])},
+    {"name": "notify_user",
+     "description": ("Alert the user when you need them SHORTLY — to finish a login, approve a 2FA "
+                     "prompt, solve a captcha, or make a decision only they can. Call this the moment "
+                     "you hit a step only the human can do."),
+     "input_schema": _obj({"message": {"type": "string"}}, ["message"])},
+    {"name": "request_focus",
+     "description": ("Ask the user's permission BEFORE a focus-stealing step you'll do via other "
+                     "tools. Pops a one-click Go ahead / Cancel dialog and returns their choice."),
+     "input_schema": _obj({"reason": {"type": "string"}}, ["reason"])},
+    {"name": "trash",
+     "description": ("Move file(s)/folder(s) to the Trash by path — focus-free and reversible. Use "
+                     "this to delete files instead of driving Finder."),
+     "input_schema": _obj({"paths": {"type": "array", "items": {"type": "string"}}}, ["paths"])},
+    {"name": "file_op",
+     "description": ("Focus-free filesystem ops by path: op='move'|'copy' (src -> dst) or op='mkdir' "
+                     "(create a folder at src). For MULTIPLE operations pass batch=[{op,src,dst},...] "
+                     "in ONE call (e.g. sort a whole folder at once). To delete, use trash."),
+     "input_schema": _obj({"op": {"type": "string", "enum": ["move", "copy", "mkdir"]},
+                           "src": {"type": "string"}, "dst": {"type": "string"},
+                           "batch": {"type": "array", "items": {
+                               "type": "object", "properties": {
+                                   "op": {"type": "string", "enum": ["move", "copy", "mkdir"]},
+                                   "src": {"type": "string"}, "dst": {"type": "string"}},
+                               "required": ["op", "src"]}}})},
+    {"name": "open_file",
+     "description": ("Open a file/folder/URL/app-deep-link with its default (or a named) app — "
+                     "focus-free launch (also 'mailto:', 'spotify:track:...')."),
+     "input_schema": _obj({"path": {"type": "string"}, "app": {"type": "string"}}, ["path"])},
+    {"name": "reveal_in_finder",
+     "description": "Reveal/select item(s) in a Finder window by path (this does front Finder).",
+     "input_schema": _obj({"paths": {"type": "array", "items": {"type": "string"}}}, ["paths"])},
+    {"name": "clipboard_get", "description": "Read the clipboard's text — focus-free (no ⌘C).",
+     "input_schema": _obj()},
+    {"name": "clipboard_set", "description": "Put text on the clipboard — focus-free (no ⌘V).",
+     "input_schema": _obj({"text": {"type": "string"}}, ["text"])},
+    {"name": "applescript",
+     "description": ("Run AppleScript to control scriptable native apps FOCUS-FREE via Apple Events "
+                     "— Mail, Messages, Notes, Reminders, Calendar, Music, Finder, Safari. Prefer "
+                     "this over UI-driving those apps. Risky scripts prompt the user."),
+     "input_schema": _obj({"script": {"type": "string"}}, ["script"])},
+]
+
+for _tool in BASE_TOOLS:
+    if _tool["name"] in ("act", "web_act"):
+        _tool["description"] += " Set detailed=true for a structured receipt; optional postcondition verifies a final field value, not every intermediate action."
+        _tool["input_schema"]["properties"].update({
+            "detailed": {"type": "boolean"},
+            "postcondition": _obj({"ref": {"type": "string"},
+                                   "field": {"type": "string", "enum": ["value", "title", "enabled", "selected", "expanded"]},
+                                   "equals": {"type": ["string", "number", "boolean", "null"]}}, ["ref", "field", "equals"])})
+
+RECOVERY_TOOLS = [
+    {"name": "app_target", "description": "Inspect exact running processes and native windows; optionally select without activation. Use inventory='installed' for a separate bounded bundle inventory.",
+     "input_schema": _obj({"app": {"type": "string"}, "window": {"type": "string"}, "select": {"type": "boolean"},
+                           "inventory": {"type": "string", "enum": ["running", "installed"]}})},
+    {"name": "app_capabilities", "description": "Inspect operation-specific AX/CDP evidence and bounded recovery options.",
+     "input_schema": _obj({"app": {"type": "string"}, "operation": {"type": "string"}}, ["app"])},
+    {"name": "app_recover", "description": "Execute a fresh target-bound recovery plan under current host policy.",
+     "input_schema": _obj({"plan_id": {"type": "string"}, "target_id": {"type": "string"}}, ["plan_id"])},
+]
+
+
+def catalog(mode="runtime"):
+    if mode != "runtime":
+        raise ValueError("unknown tool catalog")
+    return [{**tool, "input_schema": {**tool["input_schema"], "additionalProperties": False}}
+            for tool in BASE_TOOLS + RECOVERY_TOOLS]
+
+
+def catalog_for(mac):
+    return catalog()
+
+
+def validate_arguments(name, arguments):
+    """Apply the same model-call contract after every transport's decoding."""
+    from jsonschema import Draft202012Validator
+    from .errors import HunchError
+    definition = next(tool for tool in catalog() if tool["name"] == name)
+    schema = {**definition["input_schema"], "additionalProperties": False}
+    if isinstance(arguments, dict):
+        # MCP wrappers supply None for omitted optional parameters. Preserve explicit
+        # nullable values and required fields; normalize only omission sentinels.
+        arguments = {key: value for key, value in arguments.items()
+                     if value is not None or key in schema.get("required", [])
+                     or "null" in schema.get("properties", {}).get(key, {}).get("type", [])}
+    error = next(Draft202012Validator(schema).iter_errors(arguments), None)
+    if error:
+        # Do not echo input values (which may contain protected app data).
+        path = ".".join(str(part) for part in error.absolute_path) or "arguments"
+        raise HunchError(f"invalid {name} {path}: violates {error.validator}; use the published tool schema")
+    return arguments

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -83,7 +83,7 @@ class _FakeHunch:
         self._rec("snapshot")
         return f"tree of {app or 'frontmost'}"
 
-    def act(self, actions, reason="", confirm=False):
+    def act(self, actions, reason="", confirm=False, detailed=False, postcondition=None):
         self._rec("act")
         return "acted"
 
@@ -161,7 +161,7 @@ def test_approval_denied_maps_to_content():
 def test_unexpected_error_is_error_flag():
     tu = tool_block("file_op", {"op": "move"}, "t1")   # missing src -> KeyError path? uses .get, so
     # force a genuine unexpected error via a broken dispatch arg
-    tu = tool_block("clipboard_set", {}, "t1")         # missing required 'text' -> KeyError
+    tu = tool_block("clipboard_set", {"text": "fixture"}, "t1")  # missing backend -> AttributeError
     res = _run_tool(_FakeHunchClipboardless(), tu)
     assert res["is_error"] is True and res["content"].startswith("error:")
 

--- a/tests/test_ax_press.py
+++ b/tests/test_ax_press.py
@@ -93,6 +93,39 @@ def test_click_checkbox_failure_teaches_ax_path(monkeypatch):
     assert "val='0'" in out and "defaults write" in out
 
 
+def test_click_text_field_focuses_instead_of_confirming(monkeypatch):
+    """Native sheets may advertise AXConfirm on a text field. Clicking the ref
+    must focus the editor so a following Return reaches it."""
+    s = _bare_session()
+    s.registry = {"e3": "field"}
+    state = {"focused": False}
+    fired = []
+
+    def get_attr(el, attr):
+        if attr == ax.kAXRoleAttribute:
+            return "AXTextField"
+        if attr == lm.kAXFocusedAttribute:
+            return state["focused"]
+        return None
+
+    monkeypatch.setattr(ax, "get_attr", get_attr)
+    monkeypatch.setattr(
+        lm,
+        "AXUIElementSetAttributeValue",
+        lambda el, attr, value: state.update(focused=value) or 0,
+    )
+    monkeypatch.setattr(lm.MacSession, "_ax_activate", lambda self, el: fired.append(el))
+    monkeypatch.setattr(lm.time, "sleep", lambda seconds: None)
+
+    assert s.click("e3") == "focused e3"
+    assert state["focused"] is True
+    assert fired == []
+
+
+def test_backspace_is_a_key_alias_not_literal_text():
+    assert lm._KEYCODES["backspace"] == lm._KEYCODES["delete"] == 51
+
+
 def test_ax_fire_prefers_alternative_action_over_toggle(monkeypatch):
     monkeypatch.setattr(lm, "AXUIElementPerformAction",
                         lambda el, a: 0 if a == "AXOpen" else -25200)

--- a/tests/test_capability_contracts.py
+++ b/tests/test_capability_contracts.py
@@ -1,0 +1,66 @@
+from types import SimpleNamespace
+
+import pytest
+
+from hunch import local_mac, sdk
+from hunch.targets import TargetError, TargetRegistry, select_running
+
+
+def test_duplicate_identity_requires_pid():
+    apps = [{"pid": p, "name": "Loom", "bundle_id": "com.loom", "path": "/Applications/Loom.app"}
+            for p in (1, 2)]
+    for query in ("Loom", "com.loom", "/Applications/Loom.app"):
+        with pytest.raises(TargetError, match="pid:1.*pid:2"):
+            select_running(query, apps)
+    assert select_running("pid:2", apps)["pid"] == 2
+
+
+def test_window_handles_expire_on_process_restart():
+    registry = TargetRegistry()
+    element = object()
+    first = registry.bind({"pid": 1, "started_at": "a"}, [(element, ["AXFocusedWindow"])])[0]
+    registry.bind({"pid": 1, "started_at": "b"}, [(element, ["AXMainWindow"])])
+    with pytest.raises(TargetError, match="stale"):
+        registry.window(first.handle)
+
+
+@pytest.mark.parametrize("trusted", [False, True])
+@pytest.mark.parametrize("window", [None, "minimal-window"])
+def test_observation_never_restarts(monkeypatch, trusted, window):
+    session = local_mac.MacSession.__new__(local_mac.MacSession)
+    session.registry, session._keymap, session._ref_keys = {}, {}, {}
+    identity = {"pid": 42, "name": "Fake"}
+    monkeypatch.setattr(local_mac, "_resolve_app", lambda _: identity)
+    monkeypatch.setattr(local_mac, "AXUIElementCreateApplication", lambda _: "app")
+    monkeypatch.setattr(local_mac, "AXIsProcessTrusted", lambda: trusted)
+    monkeypatch.setattr(local_mac, "_embedded_chromium", lambda _: True)
+    monkeypatch.setattr(local_mac, "_enable_manual_ax", lambda _: None)
+    monkeypatch.setattr(local_mac.ax, "get_window", lambda _: window)
+    monkeypatch.setattr(local_mac, "launch_app", lambda *a, **k: pytest.fail("observation relaunched"))
+    win, _, error = session._resolve_window("Fake")
+    assert win == window
+    if error:
+        assert "blocks AX entirely" not in error[0]
+        if not trusted:
+            assert "NOT trusted" in error[0]
+
+
+def test_launch_failure_does_not_claim_success(monkeypatch):
+    monkeypatch.setattr(local_mac, "_resolve_app", lambda _: None)
+    monkeypatch.setattr(local_mac.subprocess, "run", lambda *a, **k: SimpleNamespace(returncode=1, stderr="missing"))
+    assert local_mac.launch_app("Missing", background=True) == "failed to launch Missing: missing"
+
+
+def test_sdk_uses_fresh_foreground(monkeypatch):
+    monkeypatch.setattr(local_mac, "_frontmost", lambda: ("Fresh", 7))
+    assert sdk._frontmost() == "Fresh"
+
+
+def test_native_refs_expire_when_process_identity_changes(monkeypatch):
+    session = local_mac.MacSession.__new__(local_mac.MacSession)
+    session._identity = {"pid": 7, "started_at": "first"}
+    session.registry, session._keymap, session._ref_keys = {"e1": object()}, {"a": "e1"}, {"e1": "a"}
+    monkeypatch.setattr(local_mac, "_running_identity", lambda _: {"pid": 7, "started_at": "second"})
+    with pytest.raises(local_mac.StaleRef):
+        session._el("e1")
+    assert not session.registry

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -18,8 +18,10 @@ from hunch.errors import HunchError
 
 
 class _FakeHunch:
-    def __init__(self):
+    def __init__(self, confirm=None):
         self._app_id = None
+        if confirm is not None:
+            self._gate = types.SimpleNamespace(confirm=confirm)
 
 
 # ── provider registry ─────────────────────────────────────────────────────────
@@ -90,6 +92,44 @@ def test_codex_config_overrides_register_hunch_server():
     assert "mcp_servers.hunch.command=" in joined
     assert 'mcp_servers.hunch.args=["-m", "hunch", "serve"]' in joined
     assert "mcp_servers.hunch.env.HOME=" in joined and "mcp_servers.hunch.env.PATH=" in joined
+    assert "HUNCH_NO_INTERNAL_GATE" not in joined
+    assert "default_tools_approval_mode" not in joined
+
+
+def test_codex_unattended_instance_auto_approves_only_hunch_tools():
+    ov = CodexBackend(_FakeHunch(confirm="off"))._config_overrides()
+    joined = "\n".join(ov)
+    assert 'mcp_servers.hunch.env.HUNCH_NO_INTERNAL_GATE="1"' in joined
+    assert 'mcp_servers.hunch.default_tools_approval_mode="approve"' in joined
+    assert "approval_policy" not in joined
+
+
+def test_codex_explicit_gate_environment_reaches_private_server(monkeypatch):
+    monkeypatch.setenv("HUNCH_NO_INTERNAL_GATE", "1")
+    joined = "\n".join(CodexBackend(_FakeHunch())._config_overrides())
+    assert 'mcp_servers.hunch.env.HUNCH_NO_INTERNAL_GATE="1"' in joined
+    assert 'mcp_servers.hunch.default_tools_approval_mode="approve"' in joined
+
+
+def test_codex_dialog_instance_keeps_both_approval_layers():
+    ov = CodexBackend(_FakeHunch(confirm="dialog"))._config_overrides()
+    joined = "\n".join(ov)
+    assert "HUNCH_NO_INTERNAL_GATE" not in joined
+    assert "default_tools_approval_mode" not in joined
+
+
+def test_codex_can_trust_private_hunch_tools_without_disabling_hunch_gates():
+    h = _FakeHunch(confirm="dialog")
+    h._trust_private_hunch_tools = True
+    joined = "\n".join(CodexBackend(h)._config_overrides())
+    assert 'mcp_servers.hunch.default_tools_approval_mode="approve"' in joined
+    assert "HUNCH_NO_INTERNAL_GATE" not in joined
+
+
+
+
+
+
 
 
 def test_codex_instructions_carry_playbook():

--- a/tests/test_editor_terminal.py
+++ b/tests/test_editor_terminal.py
@@ -124,10 +124,10 @@ def test_pick_workbench_prefers_the_requested_folder():
     # trailing slash, and a folder whose window is open with a file focused
     assert cdp._pick_workbench(pages, "/Users/me/hunch/")["id"] == "2"
     assert cdp._pick_workbench(pages, "/Users/me/C63")["id"] == "1"
-    # no window has it -> falls back to a real workbench, and the CALLER must not claim success
-    assert cdp._pick_workbench(pages, "/Users/me/absent")["id"] == "1"
+    # Several unmatched windows are ambiguous; never choose by list order.
+    assert cdp._pick_workbench(pages, "/Users/me/absent") is None
     # no folder asked for -> unchanged first-workbench behaviour
-    assert cdp._pick_workbench(pages)["id"] == "1"
+    assert cdp._pick_workbench(pages) is None
 
 
 def test_title_matching_is_dash_delimited_not_substring():
@@ -194,14 +194,16 @@ def test_editor_session_does_not_auto_follow_new_windows():
     assert s.target_id == "1"
 
 
-def test_editor_session_rebinds_when_its_own_window_closes():
+def test_editor_session_refuses_replacement_when_its_own_window_closes():
     s = _FakeTargets([_win(1, "README.md — hunch")])
     s.editor = True
     s.pinned = "/Users/me/hunch"
     s.target_id = "9"          # our window is gone
     s._known_targets = {"9"}
-    assert s._follow_new_tab() is True
-    assert s.target_id == "1"
+    import pytest
+    with pytest.raises(RuntimeError, match="explicitly select"):
+        s._follow_new_tab()
+    assert s.target_id == "9"
 
 
 # ── web.open(editor) must verify the workspace, never assert it ────────────────
@@ -242,6 +244,8 @@ def _web_with(session, monkeypatch):
     """A real Web object running the real _open_editor, with only the CDP launch stubbed."""
     from hunch import sdk
     web = object.__new__(sdk.Web)
+    from types import SimpleNamespace
+    web._h, web.profile = SimpleNamespace(app_id=None), None
     web.close = lambda: None
     monkeypatch.setattr(cdp, "CDPComputer", lambda *a, **k: _StubEditorComputer(session))
     return web

--- a/tests/test_recovery_contracts.py
+++ b/tests/test_recovery_contracts.py
@@ -1,0 +1,372 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from hunch import Hunch, cdp, local_mac
+from hunch.agent import _dispatch_core
+from hunch.backends.codex import CodexBackend
+from hunch.capabilities import Capabilities
+from hunch.errors import ApprovalDenied, HunchError
+from hunch.tool_registry import catalog
+
+
+def test_inherited_endpoint_listener_parsing(monkeypatch):
+    monkeypatch.setattr(cdp.subprocess, "run", lambda *a, **k: SimpleNamespace(
+        returncode=0, stdout="p10\nR1\nf57\nd0xabc\nn127.0.0.1:9222\np20\nR10\nf57\nd0xabc\n"))
+    assert cdp._endpoint_owner(cdp._endpoint_listeners(9222)) == 10
+
+
+@pytest.mark.parametrize("listeners", [
+    {},
+    {10: {"parent": 1, "sockets": {"0xabc"}}, 20: {"parent": 1, "sockets": {"0xabc"}}},
+    {10: {"parent": 1, "sockets": {"0xabc"}}, 20: {"parent": 10, "sockets": {"0xdef"}}},
+    {10: {"parent": 1, "sockets": set()}, 20: {"parent": 10, "sockets": set()}},
+    {10: {"parent": 20, "sockets": {"0xabc"}}, 20: {"parent": 10, "sockets": {"0xabc"}}},
+])
+def test_ambiguous_endpoint_owners_refused(listeners):
+    assert cdp._endpoint_owner(listeners) is None
+
+
+def test_inherited_endpoint_identity_rechecks_ownership(monkeypatch):
+    listeners = {10: {"parent": 1, "sockets": {"0xabc"}},
+                 20: {"parent": 10, "sockets": {"0xabc"}}}
+    identity = {"pid": 10, "started_at": "original", "path": "/Applications/Test.app"}
+    monkeypatch.setattr(cdp, "_endpoint_listeners", lambda _: listeners)
+    monkeypatch.setattr(local_mac, "_running_identity", lambda _: identity)
+    assert cdp.endpoint_identity(9222) == identity
+    reads = iter([listeners, {}])
+    monkeypatch.setattr(cdp, "_endpoint_listeners", lambda _: next(reads))
+    with pytest.raises(RuntimeError, match="ownership changed"):
+        cdp.endpoint_identity(9222)
+
+
+def test_inherited_endpoint_refuses_pid_reuse(monkeypatch):
+    listeners = {10: {"parent": 1, "sockets": {"0xabc"}},
+                 20: {"parent": 10, "sockets": {"0xabc"}}}
+    monkeypatch.setattr(cdp, "_endpoint_listeners", lambda _: listeners)
+    reads = iter([{"pid": 10, "started_at": "old"}, {"pid": 10, "started_at": "new"}])
+    monkeypatch.setattr(local_mac, "_running_identity", lambda _: next(reads))
+    with pytest.raises(RuntimeError, match="ownership changed"):
+        cdp.endpoint_identity(9222)
+
+
+
+
+def test_host_background_constraint_cannot_be_weakened(monkeypatch):
+    mac = Hunch(check_permissions=False, background_only=True, confirm="off")
+    with pytest.raises(ApprovalDenied):
+        mac.simultaneous = False
+    with pytest.raises(ApprovalDenied):
+        mac.focus_app("Finder")
+    with pytest.raises(ApprovalDenied):
+        mac.files.reveal(["/tmp/a"])
+    assert mac.applescript('tell application "Finder" to activate').startswith("REFUSED")
+
+
+def test_fallback_checks_policy_even_if_already_frontmost(monkeypatch):
+    mac = Hunch(check_permissions=False, confirm=lambda request: False)
+    session = mac._computer.session
+    session._pid = 7
+    monkeypatch.setattr(local_mac, "_frontmost", lambda: ("Fake", 7))
+    monkeypatch.setattr(local_mac, "_mouse_click", lambda *a, **k: pytest.fail("denied input"))
+    assert session.activate() is False
+
+
+def test_cdp_refuses_unowned_reuse(monkeypatch):
+    monkeypatch.setattr(cdp.urllib.request, "urlopen", lambda *a, **k: SimpleNamespace(read=lambda: b"{}"))
+    monkeypatch.setattr(cdp, "verify_endpoint", lambda *a: {"pid": 1})
+    monkeypatch.setattr(cdp, "_OWNED_ENDPOINTS", {})
+    monkeypatch.setattr(cdp.subprocess, "run", lambda *a, **k: pytest.fail("unexpected launch"))
+    with pytest.raises(RuntimeError, match="already in use"):
+        cdp.launch_chromium("Loom", 9472)
+
+
+def test_cdp_cannot_quit_unowned_port(monkeypatch):
+    monkeypatch.setattr(cdp, "_OWNED_ENDPOINTS", {})
+    with pytest.raises(RuntimeError, match="unowned"):
+        cdp.quit_cdp(9472)
+
+
+def test_recovery_plan_expires_on_pid_reuse(monkeypatch):
+    mac = Hunch(check_permissions=False, confirm="off")
+    recovery = mac._capabilities
+    plan = recovery._plan({"pid": 1, "started_at": "old"}, "observe", "enable_ax")
+    monkeypatch.setattr(local_mac, "_running_identity", lambda _: {"pid": 1, "started_at": "new"})
+    with pytest.raises(HunchError, match="changed"):
+        recovery.recover(plan["plan_id"])
+    with pytest.raises(HunchError, match="already attempted"):
+        recovery.recover(plan["plan_id"])
+
+
+def test_recovery_refuses_changed_host_constraints(monkeypatch):
+    mac = Hunch(check_permissions=False, confirm="off")
+    identity = {"pid": 1}
+    plan = mac._capabilities._plan(identity, "observe", "enable_ax")
+    monkeypatch.setattr(local_mac, "_running_identity", lambda _: identity)
+    mac.simultaneous = True
+    with pytest.raises(HunchError, match="constraints changed"):
+        mac.recover(plan["plan_id"])
+
+
+def test_codex_serializes_instance_configuration():
+    mac = Hunch(check_permissions=False, confirm="off", background_only=True,
+                app_id="test.example", cdp_port=9891, cdp_profile="/tmp/test-profile")
+    _, _, env = CodexBackend(mac)._mcp_server_command()
+    config = json.loads(env["HUNCH_RUNTIME_CONFIG"])
+    assert config["background_only"] and config["simultaneous"]
+    assert config["cdp_port"] == 9891 and config["cdp_profile"] == "/tmp/test-profile"
+    assert config["app_id"] == "test.example"
+
+
+def test_codex_rejects_live_callback():
+    mac = Hunch(check_permissions=False, confirm=lambda _: False)
+    with pytest.raises(HunchError, match="live host callbacks"):
+        CodexBackend(mac)._mcp_server_command()
+
+
+def test_secret_echo_redaction_and_screenshot_refusal(monkeypatch):
+    mac = Hunch(check_permissions=False)
+    mac._secrets.add("synthetic-secret")
+    monkeypatch.setattr(mac, "list_apps", lambda: "echo synthetic-secret")
+    value, error = _dispatch_core(mac, "list_apps", {})
+    assert not error and value == "echo [REDACTED]"
+    with pytest.raises(HunchError, match="screenshot blocked"):
+        mac.screenshot()
+    with pytest.raises(HunchError, match="screenshot blocked"):
+        mac.web.screenshot()
+
+
+def test_cdp_never_follows_unrelated_popup(monkeypatch):
+    session = cdp.CDPSession(9472)
+    session.target_id = "main"
+    session._known_targets = {"main"}
+    monkeypatch.setattr(session, "_list_page_targets", lambda: [
+        {"id": "helper", "openerId": "another"}, {"id": "main"}])
+    monkeypatch.setattr(session, "_open_ws", lambda _: pytest.fail("followed unrelated target"))
+    assert not session._follow_new_tab()
+
+
+def test_ax_permission_denial_still_offers_cdp_attachment(monkeypatch):
+    mac = Hunch(check_permissions=False)
+    recovery = mac._capabilities
+    monkeypatch.setattr(recovery, "targets", lambda _: {
+        "target": {"pid": 17}, "trusted": False, "windows": []})
+    monkeypatch.setattr(local_mac, "_proc_cmdline", lambda _: "App --remote-debugging-port=9222")
+    monkeypatch.setattr(local_mac, "_embedded_chromium", lambda _: True)
+    result = recovery.inspect("App")
+    assert result["status"] == "permission_denied"
+    assert [p["action"] for p in result["recoveries"]] == ["attach_cdp"]
+
+
+def test_attachment_rejects_other_process_of_same_app(monkeypatch):
+    mac = Hunch(check_permissions=False)
+    monkeypatch.setattr(cdp, "verify_endpoint", lambda *a: {"pid": 8, "path": "/App.app"})
+    with pytest.raises(HunchError, match="different process"):
+        mac.web.attach("/App.app", 9222, expected_identity={"pid": 7, "path": "/App.app"})
+
+
+def test_websocket_metadata_cannot_redirect_connection(monkeypatch):
+    session = cdp.CDPSession(9222)
+    monkeypatch.setattr(cdp.websocket, "create_connection", lambda *a, **k: pytest.fail("network call"))
+    for url in ("ws://example.com:9222/devtools/page/1", "ws://127.0.0.1:9223/devtools/page/1"):
+        with pytest.raises(RuntimeError, match="outside"):
+            session._open_ws({"webSocketDebuggerUrl": url})
+
+
+def test_one_sdk_cannot_quit_another_sdk_browser(monkeypatch):
+    first = Hunch(check_permissions=False)
+    second = Hunch(check_permissions=False)
+    monkeypatch.setattr(cdp, "_OWNED_ENDPOINTS", {9222: {"owner": first.web._owner}})
+    monkeypatch.setattr(cdp, "endpoint_identity", lambda _: pytest.fail("must refuse before OS access"))
+    with pytest.raises(RuntimeError, match="unowned"):
+        cdp.quit_cdp(9222, owner=second.web._owner)
+
+
+def test_secret_fill_does_not_fall_back_to_keyboard(monkeypatch):
+    session = cdp.CDPSession(9222)
+    session.registry["e1"] = 123
+    calls = []
+    def command(method, params=None):
+        calls.append(method)
+        if method == "DOM.resolveNode":
+            return {"object": {"objectId": "field"}}
+        return {"result": {"value": False}}
+    monkeypatch.setattr(session, "validate_document", lambda: None)
+    monkeypatch.setattr(session, "_cmd", command)
+    assert not session.fill_secret("e1", "fixture-secret", "https://example.com/form")
+    assert calls == ["DOM.resolveNode", "Runtime.callFunctionOn"]
+
+
+def test_screen_approval_does_not_cross_targets():
+    from hunch.gate import Gate
+    permission = Gate(confirm=lambda _: True)
+    permission.bind_screen_target(("pid:1", "start-one"))
+    permission.mark_screen_approval()
+    assert permission.screen_approved()
+    permission.bind_screen_target(("pid:1", "start-two"))
+    assert not permission.screen_approved()
+
+
+@pytest.mark.parametrize("update_status,add_status,expected", [(0, 0, ["update"]),
+                                                          (-25300, 0, ["update", "add"]),
+                                                          (-25293, 0, ["update"])])
+def test_keychain_writes_use_native_api_without_secret_argv(monkeypatch, update_status, add_status, expected):
+    from hunch import creds
+    calls = []
+    def update(*args):
+        calls.append("update")
+        return update_status
+    def add(*args):
+        calls.append("add")
+        return add_status
+    monkeypatch.setattr(creds, "_security_framework", lambda: (
+        SimpleNamespace(SecItemUpdate=update, SecItemAdd=add), lambda name: name))
+    monkeypatch.setattr(creds.subprocess, "run", lambda *a, **k: pytest.fail("secret subprocess"))
+    if update_status == -25293:
+        with pytest.raises(RuntimeError, match="OSStatus -25293"):
+            creds._store_keychain_blob("fixture", "account", "synthetic-secret")
+    else:
+        creds._store_keychain_blob("fixture", "account", "synthetic-secret")
+    assert calls == expected
+
+
+def test_installed_inventory_is_separate_and_bounded(tmp_path):
+    import plistlib
+    from hunch.targets import installed_apps
+    for name in ("One", "Two"):
+        contents = tmp_path / f"{name}.app" / "Contents"
+        contents.mkdir(parents=True)
+        (contents / "Info.plist").write_bytes(plistlib.dumps({
+            "CFBundleName": name, "CFBundleIdentifier": f"test.{name}",
+            "CFBundleShortVersionString": "1.2"}))
+    result = installed_apps(roots=[str(tmp_path)], limit=1)
+    assert result["truncated"] and result["scanned"] == 1
+    assert result["installed"][0]["version"] == "1.2"
+    assert "pid" not in result["installed"][0]
+
+
+def test_login_retains_existing_editor_session(monkeypatch):
+    mac = Hunch(check_permissions=False)
+    session = SimpleNamespace(wait_ready=lambda: None, mark=lambda: None)
+    computer = SimpleNamespace(editor=True, session=session)
+    mac.web._computer = computer
+    monkeypatch.setattr(mac.web, "_session", lambda: session)
+    monkeypatch.setattr(cdp, "quit_cdp", lambda *a, **k: pytest.fail("login restarted editor"))
+    assert "background" in mac.web.login()
+    assert mac.web._computer is computer
+
+
+def test_explicit_port_disables_automatic_allocation(monkeypatch):
+    mac = Hunch(check_permissions=False)
+    assert mac.web._auto_port
+    mac.web.port = 9222
+    assert not mac.web._auto_port
+    assert mac.web._launch_port() == 9222
+
+
+def test_model_arguments_cannot_self_approve(monkeypatch):
+    mac = Hunch(check_permissions=False)
+    monkeypatch.setattr(mac, "act", lambda *a, **k: pytest.fail("self-approved action"))
+    result, error = _dispatch_core(mac, "act", {"actions": [], "confirm": True})
+    assert not error and "additionalProperties" in result
+
+
+def test_detailed_receipt_requires_explicit_readback_for_verification():
+    from hunch.results import action_receipt
+    args = (["pressed"], 1, "ax", {"pid": 1}, {})
+    assert action_receipt(*args)["status"] == "performed_unverified"
+    condition = {"ref": "e1", "field": "value", "equals": "wanted"}
+    assert action_receipt(*args, condition, lambda *a: "different")["status"] == "performed_unverified"
+    assert action_receipt(*args, condition, lambda *a: "wanted")["status"] == "verified"
+    failed = action_receipt(["refused"], 2, "ax", {}, {}, condition,
+                            lambda *a: pytest.fail("readback after blocked prerequisite"))
+    assert failed["status"] == "blocked" and failed["unattempted_actions"] == 1
+
+
+def test_native_detailed_action_verifies_field_after_dispatch(monkeypatch):
+    mac = Hunch(check_permissions=False, background_only=True)
+    computer = mac._computer
+    monkeypatch.setattr(local_mac.time, "sleep", lambda _: None)
+    monkeypatch.setattr(computer, "snapshot", lambda: "[e1] AXTextField")
+    monkeypatch.setattr(computer.session, "set_text", lambda *a, **k: "set field")
+    monkeypatch.setattr(computer.session, "_el", lambda _: object())
+    monkeypatch.setattr(local_mac.ax, "read_attr", lambda *a: (0, "actual"))
+    result = mac.act([{"action": "type", "ref": "e1", "text": "wanted"}], detailed=True,
+                     postcondition={"ref": "e1", "field": "value", "equals": "wanted"})
+    assert result["status"] == "performed_unverified"
+    assert not result["postcondition"]["matched"]
+    monkeypatch.setattr(local_mac.ax, "read_attr", lambda *a: (0, "wanted"))
+    result = mac.act([{"action": "type", "ref": "e1", "text": "wanted"}], detailed=True,
+                     postcondition={"ref": "e1", "field": "value", "equals": "wanted"})
+    assert result["status"] == "verified" and result["disturbances"] == {}
+
+
+def test_codex_child_applies_serialized_host_configuration():
+    import os
+    import subprocess
+    import sys
+    mac = Hunch(check_permissions=False, background_only=True, confirm="off",
+                app_id="test.child", cdp_port=9789, cdp_profile="/tmp/child-profile")
+    _, _, overrides = CodexBackend(mac)._mcp_server_command()
+    code = ("import json; from hunch.server import _mac; "
+            "print(json.dumps({'background':_mac.background_only, 'app_id':_mac.app_id, "
+            "'port':_mac.web.port, 'profile':_mac.web.profile, 'simultaneous':_mac.simultaneous}))")
+    child = subprocess.run([sys.executable, "-c", code], env={**os.environ, **overrides},
+                           capture_output=True, text=True, check=True)
+    assert json.loads(child.stdout) == {"background": True, "app_id": "test.child", "port": 9789,
+                                       "profile": "/tmp/child-profile", "simultaneous": True}
+
+
+def test_codex_does_not_drop_secret_protection_state():
+    mac = Hunch(check_permissions=False)
+    mac._secrets.add("fixture-secret")
+    with pytest.raises(HunchError, match="secret-output protection"):
+        CodexBackend(mac)._mcp_server_command()
+
+
+def test_failed_graceful_cdp_quit_never_forces(monkeypatch):
+    import AppKit
+    owner = object()
+    identity = {"pid": 123, "started_at": "fixture"}
+    calls = []
+    process = SimpleNamespace(terminate=lambda: calls.append("terminate"), isTerminated=lambda: False,
+                              forceTerminate=lambda: pytest.fail("force quit"))
+    monkeypatch.setattr(AppKit, "NSRunningApplication", SimpleNamespace(
+        runningApplicationWithProcessIdentifier_=lambda _: process))
+    monkeypatch.setattr(cdp, "_OWNED_ENDPOINTS", {9222: {"owner": owner, "identity": identity}})
+    monkeypatch.setattr(cdp, "endpoint_identity", lambda _: identity)
+    monkeypatch.setattr(local_mac, "_process_alive", lambda _: True)
+    clock = iter([0, 7])
+    monkeypatch.setattr(cdp.time, "monotonic", lambda: next(clock))
+    with pytest.raises(RuntimeError, match="did not quit gracefully"):
+        cdp.quit_cdp(9222, owner=owner)
+    assert calls == ["terminate"] and 9222 in cdp._OWNED_ENDPOINTS
+
+
+def test_ready_requested_workspace_does_not_wait_for_other_windows(monkeypatch):
+    session = cdp.CDPSession(9222)
+    pages = [{"id": "one", "title": "One", "url": "file:///workbench.html"},
+             {"id": "two", "title": "Two", "url": "file:///workbench.html"}]
+    monkeypatch.setattr(session, "_list_page_targets", lambda: pages)
+    picked = []
+    monkeypatch.setattr(session, "_open_ws", lambda page: picked.append(page["id"]))
+    monkeypatch.setattr(cdp.time, "sleep", lambda _: pytest.fail("unnecessary renderer wait"))
+    session.connect(editor=True, folder="/tmp/Two")
+    assert picked == ["two"]
+
+
+def test_duplicate_workspace_titles_require_selection():
+    pages = [{"id": "one", "title": "Same", "url": "file:///workbench.html"},
+             {"id": "two", "title": "Same", "url": "file:///workbench.html"}]
+    assert cdp._pick_workbench(pages, "/tmp/Same") is None
+
+
+def test_quit_uses_kernel_liveness_instead_of_cached_app_flag(monkeypatch):
+    process = SimpleNamespace(terminate=lambda: None, isTerminated=lambda: False)
+    monkeypatch.setattr(local_mac, "_resolve_app", lambda _: {"pid": 123})
+    monkeypatch.setattr(local_mac, "NSRunningApplication", SimpleNamespace(
+        runningApplicationWithProcessIdentifier_=lambda _: process))
+    monkeypatch.setattr(local_mac, "_process_alive", lambda _: False)
+    monkeypatch.setattr(local_mac.time, "sleep", lambda _: None)
+    assert local_mac.quit_app("Fixture") == "quit Fixture"

--- a/tests/test_release_gaps.py
+++ b/tests/test_release_gaps.py
@@ -36,6 +36,11 @@ def test_activation_fallback_requires_foreground_readback(monkeypatch, front, ex
 
 
 def test_denied_activation_never_reaches_fallback(monkeypatch):
+    from hunch import gate, sdk
+    # CI can start with Finder foreground, which legitimately skips a focus gate.
+    # This case must request a real switch without reading or changing the desktop.
+    monkeypatch.setattr(gate, "_frontmost", lambda: ("Other app", 99))
+    monkeypatch.setattr(sdk, "_focus_app", lambda _: pytest.fail("denied native activation"))
     monkeypatch.setattr(local_mac, "_activate_process", lambda _: pytest.fail("denied activation"))
     with pytest.raises(ApprovalDenied):
         Hunch(check_permissions=False, background_only=True, confirm="off").focus_app("Finder")

--- a/tests/test_release_gaps.py
+++ b/tests/test_release_gaps.py
@@ -1,0 +1,77 @@
+"""Failure-boundary checks added during final capability acceptance."""
+from types import SimpleNamespace
+
+import pytest
+
+from hunch import Hunch, cdp, local_mac
+from hunch.errors import ApprovalDenied
+
+
+def test_runtime_release_excludes_learning():
+    from hunch.tool_registry import catalog
+    from hunch.agent import _dispatch_core
+    names = {tool["name"] for tool in catalog()}
+    assert len(names) == 32
+    assert {"app_target", "app_capabilities", "app_recover"} <= names
+    assert not {"app_operations", "app_invoke"} & names
+    assert not any(name.startswith("learning_") for name in names)
+    mac = Hunch(check_permissions=False)
+    assert not hasattr(mac, "learning")
+    assert _dispatch_core(mac, "learning_build", {}) == ("unknown tool learning_build", True)
+
+
+@pytest.mark.parametrize("front,expected", [(7, "focused"), (9, "UNVERIFIED")])
+@pytest.mark.parametrize("app_missing", [False, True])
+def test_activation_fallback_requires_foreground_readback(monkeypatch, front, expected, app_missing):
+    monkeypatch.setattr(local_mac, "_resolve_app", lambda _: {"pid": 7})
+    monkeypatch.setattr(local_mac, "_announce_front", lambda _: None)
+    monkeypatch.setattr(local_mac, "NSRunningApplication", SimpleNamespace(
+        runningApplicationWithProcessIdentifier_=lambda _: None if app_missing else SimpleNamespace(activateWithOptions_=lambda _: False)))
+    called = []
+    monkeypatch.setattr(local_mac, "_activate_process", lambda pid: called.append(pid) or True)
+    monkeypatch.setattr(local_mac, "_frontmost", lambda: ("app", front))
+    monkeypatch.setattr(local_mac.time, "sleep", lambda _: None)
+    assert local_mac.focus_app("test").startswith(expected)
+    assert called == [7]
+
+
+def test_denied_activation_never_reaches_fallback(monkeypatch):
+    monkeypatch.setattr(local_mac, "_activate_process", lambda _: pytest.fail("denied activation"))
+    with pytest.raises(ApprovalDenied):
+        Hunch(check_permissions=False, background_only=True, confirm="off").focus_app("Finder")
+    with pytest.raises(ApprovalDenied):
+        Hunch(check_permissions=False, confirm=lambda _: False).focus_app("Finder")
+
+
+@pytest.mark.parametrize("failure", ["port_claimed", "timeout", "profile_changed"])
+def test_failed_launch_does_not_register_ownership(monkeypatch, tmp_path, failure):
+    monkeypatch.setattr(cdp, "_OWNED_ENDPOINTS", {})
+    monkeypatch.setattr(cdp, "_resolve_app", lambda _: "Test")
+    def unavailable(*a, **k):
+        raise OSError("no listener yet")
+    monkeypatch.setattr(cdp.urllib.request, "urlopen", unavailable)
+    monkeypatch.setattr(cdp.subprocess, "run", lambda *a, **k: SimpleNamespace(returncode=0))
+    def wait(*a, **k):
+        if failure == "timeout":
+            raise RuntimeError("debug port did not open")
+    monkeypatch.setattr(cdp, "_wait_for_port", wait)
+    def verify(*a):
+        if failure == "port_claimed":
+            raise RuntimeError("port belongs to another app")
+        return {"pid": 7}
+    monkeypatch.setattr(cdp, "verify_endpoint", verify)
+    monkeypatch.setattr(local_mac, "_proc_cmdline", lambda _: "Test --user-data-dir=/wrong-profile")
+    with pytest.raises(RuntimeError):
+        cdp.launch_chromium("Test", 9222, profile=str(tmp_path))
+    assert cdp._OWNED_ENDPOINTS == {}
+
+
+@pytest.mark.parametrize("readback,requested,expected", [("wrong", 1, "performed_unverified"),
+                                                       ("wanted", 2, "performed_unverified"),
+                                                       ("wanted", 1, "verified")])
+def test_postcondition_does_not_hide_mismatch_or_incomplete_batch(readback, requested, expected):
+    from hunch.results import action_receipt
+    receipt = action_receipt(["clicked e1"], requested, "cdp", {}, {},
+                             {"ref": "e1", "field": "value", "equals": "wanted"},
+                             lambda *a: readback)
+    assert receipt["status"] == expected

--- a/tests/test_sdk_smoke.py
+++ b/tests/test_sdk_smoke.py
@@ -265,7 +265,9 @@ def test_server_is_an_app_on_the_sdk():
     """The inversion invariants: one engine (every MCP tool name resolves in the shared
     dispatch table), one Hunch instance, personal policy + notify wrapper wired in."""
     import hunch.agent as agent_mod
-    assert set(server.mcp._tool_manager._tools) == set(agent_mod._DISPATCH)
+    from hunch.tool_registry import catalog
+    assert set(server.mcp._tool_manager._tools) == {t["name"] for t in catalog()}
+    assert {t["name"] for t in catalog()} == set(agent_mod._DISPATCH)
     assert isinstance(server._mac, Hunch)
     assert server._gate is server._mac._gate
     assert server._gate._policy == "personal"

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -27,8 +27,9 @@ def test_runtime_version_matches_package_metadata():
 
 
 def test_tool_count():
-    assert len(server.mcp._tool_manager._tools) == 29
-    assert "find" in server.mcp._tool_manager._tools
+    from hunch.tool_registry import catalog
+    assert set(server.mcp._tool_manager._tools) == {t["name"] for t in catalog()}
+    assert len(server.mcp._tool_manager._tools) == 32
 
 
 def test_policy_defaults_all_on():
@@ -84,6 +85,7 @@ def test_user_attention_notifications_default_off(monkeypatch, tmp_path):
 def test_screen_approval_dedupe():
     import hunch.local_mac as local_mac
     # A fresh approval lets the front gate pass with NO dialog...
+    server._gate.bind_screen_target(("app", "SomeApp"))
     server._gate.mark_screen_approval()
     assert server._gate.screen_approved()
     assert server._gate.front_gate("SomeApp", "test") is None
@@ -140,13 +142,13 @@ def test_domain_mismatch_guard():
 
 
 # ── wrong-target guards ────────────────────────────────────────────────────────
-def test_applescript_empty_result_explains_electron_zero_windows():
-    """`count of windows` via System Events returns 0 for any Electron app, however many are
-    open. Without a reason the natural move is to retry the same script, which can never work."""
+def test_applescript_empty_result_does_not_classify_app_support():
+    """Zero windows is an observation, not an app-wide capability verdict."""
     from hunch import gate
     hint = gate.applescript_empty_hint(
         'tell application "System Events" to tell process "Cursor" to count of windows')
-    assert "Electron" in hint and "snapshot(app=" in hint
+    assert "uses accessibility" in hint and "snapshot(app=" in hint
+    assert "does not prove" in hint
     # unrelated scripts get no noise
     assert gate.applescript_empty_hint('tell application "Music" to play') == ""
     assert gate.applescript_empty_hint('tell application "System Events" to keystroke "a"') == ""
@@ -208,9 +210,9 @@ def test_playbook_covers_toggle_and_select_policy():
     pb = HUNCH_PLAYBOOK
     assert "val='0'" in pb and "val='1'" in pb
     assert "defaults write" in pb
-    assert "VISIBLE TEXT" in pb
-    assert "PERMISSION CLAIMS REQUIRE EXPLICIT EVIDENCE" in pb
-    assert "do not read `~/Library/Messages/chat.db`" in pb
+    assert "visible text" in pb
+    assert "explicit denial evidence" in pb
+    assert "Do not read ~/Library/Messages/chat.db" in pb
     assert "make at most one small native account probe" in pb
 
 

--- a/tests/test_walk.py
+++ b/tests/test_walk.py
@@ -83,6 +83,19 @@ def _big_tree():
     return win
 
 
+def test_resolve_app_prefers_bundle_id_and_exact_path_when_names_collide(monkeypatch):
+    monkeypatch.setattr(local_mac.ax, "list_apps", lambda: [
+        {"name": "Keynote", "pid": 10}, {"name": "Keynote", "pid": 20},
+    ])
+    identities = {
+        10: {"name": "Keynote", "bundle_id": "com.apple.iWork.Keynote", "path": "/Applications/Keynote.app"},
+        20: {"name": "Keynote", "bundle_id": "com.apple.Keynote", "path": "/Applications/Keynote Creator Studio.app"},
+    }
+    monkeypatch.setattr(local_mac, "_running_identity", identities.get)
+    assert local_mac._resolve_app("com.apple.iWork.Keynote")["pid"] == 10
+    assert local_mac._resolve_app("/Applications/Keynote Creator Studio.app")["pid"] == 20
+
+
 def test_row_gets_accessible_name():
     # A nameless selectable row is collapsed to ONE line labelled from its subtree.
     row = FakeEl("AXRow", children=[FakeEl("AXStaticText", value="Inbox — 3 unread")])


### PR DESCRIPTION
## Summary

Release the runtime capability-recovery improvements as hunch-sdk 0.6.4. Empty or partial AX observations no longer restart applications or imply universal lack of accessibility. Exact process/window selection and bounded recovery plans let clients discover and explicitly enable the appropriate interface.

- Add `app_target`, `app_capabilities`, and `app_recover` to a canonical 32-tool catalog.
- Verify CDP endpoint/process ownership, including inherited listeners; pin Electron renderers and invalidate stale references.
- Enforce background constraints at shared-input boundaries, verify activation through exact-PID fallback, and preserve credential destination/output protections.
- Provide detailed receipts with conservative final-field verification and preserve supported Codex subprocess configuration.

Hunch Learn, installed-operation APIs, adapters, Rust engines, and native packaging are excluded. They remain separate work; this PR uses the existing Python packaging/release workflow. No local transcripts, raw desktop evidence, or personal app data are included.

## Release

Version **0.6.4** is set in `pyproject.toml`, `hunch.__version__`, and both MCP registry version fields. The current published version is 0.6.3. Merging this PR to main triggers the existing PyPI publishing and GitHub release workflow. The publish decision now requires an explicit PyPI 404; network/server failures do not enable publication.

## Validation

- **262 tests passed** against this runtime-only checkout.
- Built wheel and sdist from this checkout; installed 0.6.4 outside the source tree and verified the exact 32-tool catalog.
- Inspected both distributions: no Learn modules, adapters, Rust engine, native binaries, or benchmark data.
- Prior live acceptance: ChatGPT Settings navigation and Cursor terminal input worked in the background; exact-PID activation worked with Finder and ChatGPT.
- `git diff --check` passed. Hosted CI is pending.

General panel postconditions and shared live-instance provider transport remain follow-up work. Codex requires a runtime compatible with the selected model. This PR does not claim universal background behavior for every app.
