### PR TITLE
Add Apple logo to the download form button

### DIFF
--- a/site/download.css
+++ b/site/download.css
@@ -8,7 +8,7 @@
 .download-form-section h2{font-size:27px;margin:0 0 26px}
 .form-field{margin-bottom:19px}
 .form-field label{display:block;font-size:15px;font-weight:600;margin-bottom:7px}
-.download-form-section span{font-weight:400;color:var(--muted);font-size:14px}
+.form-field label span,.download-form-section legend span{font-weight:400;color:var(--muted);font-size:14px}
 .form-field input{display:block;width:100%;min-width:0;padding:12px 14px;border:1px solid var(--border);border-radius:8px;background:var(--surface);color:var(--text);font:inherit;font-size:16px}
 .form-field input::placeholder{color:var(--muted)}
 .download-page :focus-visible{outline:3px solid var(--hunch);outline-offset:3px}

--- a/site/download.html
+++ b/site/download.html
@@ -31,7 +31,7 @@
       </fieldset>
       <div class="form-trap" aria-hidden="true"><label for="company_website">Leave this empty</label><input id="company_website" name="company_website" tabindex="-1" autocomplete="off"></div>
       <p class="form-notice">We store your name, email, and any social links you share with your download request. <a href="/privacy">Privacy notice</a>.</p>
-      <button class="btn primary form-submit" type="submit">Download free for macOS</button>
+      <button class="btn primary form-submit" type="submit"><span class="apple-logo" aria-hidden="true"></span><span class="download-button-label">Download free for macOS</span></button>
       <p id="form-status" class="form-status" role="status" aria-live="polite"></p>
       <p id="download-retry" hidden>Your download is ready. <a id="download-link">Download Hunch again</a>.</p>
       <noscript><p>Enable JavaScript to submit this form and download Hunch.</p></noscript>

--- a/site/download.js
+++ b/site/download.js
@@ -1,6 +1,7 @@
 (() => {
   const form = document.getElementById('download-form');
   const button = form.querySelector('button[type=submit]');
+  const buttonLabel = button.querySelector('.download-button-label');
   const status = document.getElementById('form-status');
   let pending = false;
   form.addEventListener('submit', async (event) => {
@@ -8,7 +9,7 @@
     if (pending || !form.reportValidity()) return;
     pending = true;
     button.disabled = true;
-    button.textContent = 'Preparing your download…';
+    buttonLabel.textContent = 'Preparing your download…';
     status.dataset.error = 'false';
     status.textContent = '';
     try {
@@ -24,14 +25,14 @@
       link.href = result.download_url;
       document.getElementById('download-retry').hidden = false;
       link.click();
-      button.textContent = 'Download ready';
+      buttonLabel.textContent = 'Download ready';
     } catch (error) {
       status.dataset.error = 'true';
       status.textContent = error instanceof TypeError
         ? 'Could not connect. Check your connection and try again.'
         : error.message;
       button.disabled = false;
-      button.textContent = 'Download free for macOS';
+      buttonLabel.textContent = 'Download free for macOS';
     } finally { pending = false; }
   });
 })();


### PR DESCRIPTION
Adds the homepage Apple logo to the form download button. Updates only the label during submission so the logo remains visible through loading, success, and retry states.