### PR TITLE
Fix native window binding across app aliases (0.6.5)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hunch-sdk"
-version = "0.6.4"
+version = "0.6.5"
 description = "Drive your Mac focus-free over MCP: OS APIs, AppleScript, CDP, and Accessibility."
 readme = "README.md"
 license = "Apache-2.0"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.PrithviSeran/hunch",
   "description": "Focus-free macOS control for AI agents: drive your real Mac apps in the background, no stolen focus.",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "repository": {
     "url": "https://github.com/PrithviSeran/hunch-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "pypi",
       "identifier": "hunch-sdk",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "transport": {
         "type": "stdio"
       }

--- a/src/hunch/__init__.py
+++ b/src/hunch/__init__.py
@@ -5,7 +5,7 @@ doctor) must work even when pyobjc or the MCP SDK are missing, so nothing here
 may import them. The server loads lazily via `hunch serve`.
 """
 
-__version__ = "0.6.4"
+__version__ = "0.6.5"
 
 # Public SDK surface, loaded lazily (PEP 562) so bare `import hunch` stays dependency-free.
 # Names mapped to .sdk/.agent/.local_mac pull in pyobjc; .errors/.auth/.providers stay

--- a/src/hunch/local_mac.py
+++ b/src/hunch/local_mac.py
@@ -486,8 +486,8 @@ class MacSession:
 
     def snapshot(self, app_name=None, compact=True, max_depth=None, activate_app=True,
                  ref=None, max_nodes=None, max_children=None):
-        """Compact tree of the target app's focused window (frontmost app by
-        default). Returns (text, info) and refreshes the ref registry.
+        """Compact tree of the selected window, else the app's focused window
+        (frontmost app by default). Returns (text, info) and refreshes refs.
         Pass ref='eNN' to re-walk ONLY that element's subtree (deeper defaults,
         does NOT clear other refs). max_depth/max_nodes/max_children=None ->
         defaults; when a cap truncates output, an explicit …marker line says what
@@ -502,7 +502,8 @@ class MacSession:
         win, app_name, err = self._resolve_window(app_name)
         if err is not None:
             return err
-        lines = [f"=== {app_name} — focused window (snapshot #{self.snapshot_count}) ==="]
+        scope = "selected window" if getattr(self, "_selected_window", None) else "focused window"
+        lines = [f"=== {app_name} — {scope} (snapshot #{self.snapshot_count}) ==="]
         warn = _twin_process_warning(app_name, getattr(self, "_pid", None))
         if warn:
             lines.append(warn)
@@ -547,6 +548,12 @@ class MacSession:
             self._manual_ax_identity = process_key(identity)
         win = ax.get_window(ax_app)
         selected = getattr(self, "_selected_window", None)
+        # Resolve aliases before deciding whether the caller switched apps. A
+        # name/bundle/path for the selected PID must not unpin its window just
+        # because app_target stored a pid:N selector. Failed resolution above
+        # leaves the binding intact; a reused PID still fails the identity check.
+        if selected and selected[0][0] != pid:
+            self._selected_window = selected = None
         if selected:
             observations, _ = ax.discover_windows(ax_app)
             if selected[0] != process_key(identity) or not any(w[0] == selected[1] for w in observations):

--- a/src/hunch/playbook.py
+++ b/src/hunch/playbook.py
@@ -8,6 +8,8 @@ TARGETS AND CAPABILITIES
 - list_apps lists running apps. app_target inspects exact process identities and native windows;
   select=true binds a process/window without bringing it forward. Names and bundle IDs may be
   ambiguous: use the returned pid:N selector and window handle. Reinspect after a process restart.
+  Bind a window when the user is using another window of the same app. snapshot/find preserve
+  that binding across aliases for the same process and refuse a stale selected window.
 - snapshot/find read native AX. They never launch, quit, or restart an app. An empty/partial tree,
   zero AXWindows, or a System Events zero-window result does not prove an app lacks AX support.
 - app_capabilities(app, operation) reports current evidence and bounded recovery plans. It may

--- a/src/hunch/sdk.py
+++ b/src/hunch/sdk.py
@@ -217,7 +217,9 @@ class Hunch:
     # ── native apps: AX tree ──────────────────────────────────────────────────
 
     def snapshot(self, app="", ref=None, max_depth=None, max_nodes=None, max_children=None):
-        """The app's focused window as a ref-annotated accessibility tree (focus-free).
+        """The selected window, or app's focused window, as a focus-free AX tree.
+        targets(..., window=..., select=True) pins a window across reads, including
+        reads using another name/bundle/path selector for the same process.
         Empty `app` targets the last aimed app (focus_app / launch_app /
         snapshot(app=...)), else the frontmost app. Pass ref="e42" to expand ONLY
         that element's subtree at full depth (other refs stay valid). Truncation is
@@ -228,8 +230,6 @@ class Hunch:
                                                         max_children=max_children))
         prev, prev_aimed = self._computer.app, self._aimed_app
         if app:
-            if app != self._computer.app:
-                self._computer.session._selected_window = None
             self._computer.app = app
             self._aimed_app = app
         else:
@@ -248,8 +248,6 @@ class Hunch:
         name_contains matches title/description/value as a substring."""
         prev, prev_aimed = self._computer.app, self._aimed_app
         if app:
-            if app != self._computer.app:
-                self._computer.session._selected_window = None
             self._computer.app = app
             self._aimed_app = app
         elif self._aimed_app:

--- a/tests/test_window_binding.py
+++ b/tests/test_window_binding.py
@@ -1,0 +1,115 @@
+"""Exercise SDK reads against changing, fake AX windows without touching the UI."""
+import pytest
+
+from hunch import Hunch, local_mac
+
+
+@pytest.fixture
+def bound_safari(monkeypatch):
+    safari = {"pid": 42, "name": "Safari", "bundle_id": "com.apple.Safari",
+              "path": "/Applications/Safari.app", "started_at": "original"}
+    notes = {"pid": 43, "name": "Notes", "bundle_id": "com.apple.Notes",
+             "path": "/Applications/Notes.app", "started_at": "original"}
+    apps = [safari, notes]
+    windows = {42: ["Course", "Personal"], 43: ["Notes window"]}
+    focused = {42: "Course", 43: "Notes window"}
+    reads = []
+
+    def attrs(element, names):
+        reads.append(element)
+        values = {"AXRole": "AXWindow", "AXTitle": element, "AXChildren": []}
+        return {name: values.get(name) for name in names}
+
+    monkeypatch.setattr(local_mac.ax, "list_apps", lambda: apps)
+    monkeypatch.setattr(local_mac, "_running_identity",
+                        lambda pid: next((dict(app) for app in apps if app["pid"] == pid), {}))
+    monkeypatch.setattr(local_mac, "AXUIElementCreateApplication", lambda pid: pid)
+    monkeypatch.setattr(local_mac, "AXIsProcessTrusted", lambda: True)
+    monkeypatch.setattr(local_mac, "_embedded_chromium", lambda pid: False)
+    monkeypatch.setattr(local_mac, "_twin_process_warning", lambda *args: "")
+    monkeypatch.setattr(local_mac.ax, "get_window", lambda pid: focused[pid])
+    monkeypatch.setattr(local_mac.ax, "discover_windows",
+                        lambda pid: ([(w, ["AXWindows"]) for w in windows[pid]], []))
+    monkeypatch.setattr(local_mac.ax, "get_attr",
+                        lambda element, name: attrs(element, [name])[name])
+    monkeypatch.setattr(local_mac.ax, "get_attrs", attrs)
+    monkeypatch.setattr(local_mac.MacSession, "activate",
+                        lambda *args: pytest.fail("background read activated an app"))
+    monkeypatch.setattr(local_mac, "_frontmost",
+                        lambda: pytest.fail("explicit reads followed foreground app"))
+    mac = Hunch(check_permissions=False, confirm="off", background_only=True)
+    target = mac.targets(app="Safari")
+    course = next(w["handle"] for w in target["windows"] if w["title"] == "Course")
+    mac.targets(app="pid:42", window=course, select=True)
+    reads.clear()
+    return mac, focused, windows, apps, reads
+
+
+@pytest.mark.parametrize("method", ["snapshot", "find"])
+@pytest.mark.parametrize("alias", ["", "Safari", "com.apple.Safari",
+                                  "/Applications/Safari.app", "pid:42"])
+def test_reads_stay_on_selected_window_when_user_switches(bound_safari, method, alias):
+    mac, focused, _, _, reads = bound_safari
+    read = getattr(mac, method)
+    assert "Course" in read()
+    focused[42] = "Personal"
+    reads.clear()
+    result = read(app=alias)
+    assert "Course" in result
+    assert "Personal" not in result
+    assert set(reads) == {"Course"}
+    assert "Course" in read()
+    assert not any(mac._computer.session.disturbances.values())
+    if method == "snapshot":
+        assert "selected window" in result
+
+
+@pytest.mark.parametrize("method", ["snapshot", "find"])
+def test_closed_selected_window_refuses_instead_of_following_focus(bound_safari, method):
+    mac, focused, windows, _, reads = bound_safari
+    read = getattr(mac, method)
+    read()
+    assert mac._computer.session.registry
+    windows[42].remove("Course")
+    focused[42] = "Personal"
+    reads.clear()
+    assert "selected window is stale" in read(app="Safari")
+    assert "selected window is stale" in read()
+    assert not reads
+    assert not mac._computer.session.registry
+
+
+@pytest.mark.parametrize("method", ["snapshot", "find"])
+def test_reused_pid_does_not_rebind_selected_window(bound_safari, method):
+    mac, focused, _, apps, reads = bound_safari
+    apps[0]["started_at"] = "restarted"
+    focused[42] = "Personal"
+    assert "selected window is stale" in getattr(mac, method)(app="Safari")
+    assert not reads
+
+
+@pytest.mark.parametrize("method", ["snapshot", "find"])
+def test_explicit_other_app_releases_window_binding(bound_safari, method):
+    mac, _, _, _, reads = bound_safari
+    result = getattr(mac, method)(app="Notes")
+    assert "Notes window" in result
+    assert set(reads) == {"Notes window"}
+    assert mac._computer.session._selected_window is None
+
+
+@pytest.mark.parametrize("method", ["snapshot", "find"])
+@pytest.mark.parametrize("failure", ["missing", "ambiguous"])
+def test_failed_app_resolution_preserves_window_binding(bound_safari, method, failure):
+    mac, focused, _, apps, reads = bound_safari
+    focused[42] = "Personal"
+    if failure == "ambiguous":
+        apps.append({**apps[0], "pid": 44})
+        query = "Safari"
+        expected = "ambiguous app"
+    else:
+        query = "Missing"
+        expected = "not found"
+    read = getattr(mac, method)
+    assert expected in read(app=query)
+    assert not reads
+    assert "Course" in read(app="pid:42")


### PR DESCRIPTION
Selecting a native window with `app_target` stores a `pid:N` target. A later `snapshot(app="Safari")` or `find(app="Safari")` previously cleared that window binding because the selector strings differed, causing reads to follow whichever Safari window the user activated.

Resolve the requested process before releasing a selected window. Name, bundle ID, path, and PID aliases for the same process preserve the binding; a successfully resolved different process releases it. Closed windows and reused PIDs retain the existing stale-target refusal, and failed app resolution leaves the binding intact. Snapshot output now identifies a selected window, and the playbook explains when to bind one.

Validation:
- 282 tests pass on this isolated branch, including 20 new regression cases covering aliases, foreground-window changes, closed targets, PID reuse, intentional app switches, and failed resolution.
- The 0.6.5 wheel and source distribution build successfully and pass `twine check`.
- Live Safari 26.6.2: two consecutive runs of the fix passed 23 checks each. AX snapshot/find read the bound page's body text while another disposable window was active and navigated to a different page. Closing the target returned a stale-window refusal. Hunch reads recorded zero disturbances; fixture setup deliberately raised Safari, and cleanup closed the fixtures and restored the previous view.
- Live-test limitation: initial AX window discovery and foreground setup were intermittent in other attempts, including the additional release-worktree attempt, which did not reach content assertions. This patch fixes loss of an established binding; it does not claim to resolve Safari window-discovery availability or guarantee arbitrary sites' AX coverage.

Prepare patch release 0.6.5 by updating package, runtime, and MCP manifest versions together. Merging this PR triggers the existing PyPI publishing workflow. MCP registry publication and the Homebrew formula update remain post-publication release steps.
